### PR TITLE
deepmaint disable var

### DIFF
--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -951,7 +951,8 @@ obj/item/scroll/attackby(obj/item/I, mob/living/carbon/human/M)
 		// Burrow
 		if(istype(carpy, /obj/item/card_carp/warren))
 			var/obj/structure/burrow/diggy_hole = new /obj/structure/burrow(carpy.loc)
-			diggy_hole.deepmaint_entry_point = TRUE
+			if(!diggy_hole.deep_disable)
+				diggy_hole.deepmaint_entry_point = TRUE
 			diggy_hole.isRevealed = TRUE
 			diggy_hole.isSealed = FALSE
 			diggy_hole.invisibility = 0

--- a/code/game/objects/structures/burrows.dm
+++ b/code/game/objects/structures/burrows.dm
@@ -61,6 +61,7 @@
 	var/reinforcements = 10 //Maximum number of times this burrow may recieve reinforcements
 
 	var/deepmaint_entry_point = FALSE //Will this burrow turn into a deep maint entry point upon getting collapsed?
+	var/deep_disable = TRUE //Disables random chance burrows. Unless someone maps them in or uses a different method to create a hole.
 
 	//Soj edit
 	var/dug_out = FALSE
@@ -95,7 +96,7 @@
 		break_open(TRUE)
 
 	var/turf/T = get_turf(src)
-	if(prob(3) && T.z == 2) //Bottom floor of maints only
+	if(prob(3) && T.z == 2 && !deep_disable) //Bottom floor of maints only
 		deepmaint_entry_point = TRUE
 
 	if(deepmaint_entry_point) //so we can tell at a glace what is a deep maints borrow


### PR DESCRIPTION
Adds a deep_disable var to burrows.
When set to TRUE it stops deepmaint versions of burrows from spawning.

Would like people to give a quick look across the code. I believe I caught the main ways deep maint tunnels were made. Of just random burrows. The main burrow spawned shouldn't work and crayon magic should also not create them.