### PR TITLE
Harry, you forgot your stats!

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -30,7 +30,7 @@ var/global/list/image/splatter_cache=list()
 /obj/effect/decal/cleanable/blood/examine(mob/user)
 	. = ..()
 	if(iscarbon(user) || issilicon(user))
-		if(shoe_types.len && (user.stats?.getPerk(PERK_EAR_OF_QUICKSILVER) || user.stats.getStat(STAT_VIG) >= STAT_LEVEL_EXPERT)) //Basiclly rangers are meant to do this so they have a bypass
+		if(shoe_types.len && (user.stats?.getPerk(PERK_EAR_OF_QUICKSILVER) || user.stats.getStat(STAT_COG) >= STAT_LEVEL_EXPERT)) //Basiclly rangers are meant to do this so they have a bypass / Cognition because Visual Calculus
 			to_chat(user, "<span class='info'>There is traces of shoe prints that are likely from:</span>")
 			for(var/shoe in shoe_types)
 				var/obj/item/clothing/shoes/S = shoe

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -238,7 +238,7 @@ var/list/flooring_types
 		if(!our_trippah.back) //We cannot trip if we balance ourselves with not having a backpack, including Klutz cause I don't feel like being so mean.
 			return
 		if(M.stats.getPerk(PERK_KLUTZ) || our_trippah.stats.getStat(STAT_VIG) <= 0) //Negative Vig just makes you faceslam hard. This is equal to rolling uneven number with 1 Hand/Eye Coordination. Klutz is self explanatory
-			if(prob(60))
+			if(prob(60 - our_trippah.stats.getStat(STAT_VIG)))
 				to_chat(our_trippah, SPAN_WARNING("Your poor motorics made you slam hard into the plating!"))
 				our_trippah.adjustBruteLoss(15)
 				our_trippah.trip(src, 6)

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -235,6 +235,8 @@ var/list/flooring_types
 	if(MOVING_QUICKLY(M))
 		if(M.incapacitated() || M.lying) //We cannot fall over again once we already fallen over once
 			return
+		if(!our_trippah.back) //We cannot trip if we balance ourselves with not having a backpack, including Klutz cause I don't feel like being so mean.
+			return
 		if(M.stats.getPerk(PERK_KLUTZ) || our_trippah.stats.getStat(STAT_VIG) <= 0) //Negative Vig just makes you faceslam hard. This is equal to rolling uneven number with 1 Hand/Eye Coordination. Klutz is self explanatory
 			if(prob(60))
 				to_chat(our_trippah, SPAN_WARNING("Your poor motorics made you slam hard into the plating!"))
@@ -242,8 +244,6 @@ var/list/flooring_types
 				our_trippah.trip(src, 6)
 				return
 		if(M.stats.getPerk(PERK_SURE_STEP))//You trip even with this perk if klutz or vig below 0
-			return
-		if(!our_trippah.back)
 			return
 		if(prob(50 - our_trippah.stats.getStat(STAT_VIG))) //50 VIG makes you unable to trip
 			to_chat(our_trippah, SPAN_WARNING("You gently slam into the plating!"))

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -233,13 +233,20 @@ var/list/flooring_types
 		return
 	var/mob/living/carbon/human/our_trippah = M
 	if(MOVING_QUICKLY(M))
-		if(M.stats.getPerk(PERK_SURE_STEP))
+		if(M.incapacitated() || M.lying) //We cannot fall over again once we already fallen over once
 			return
- // The art of calculating the vectors required to avoid tripping on the metal beams requires big quantities of brain power
-		if(prob(50 - our_trippah.stats.getStat(STAT_COG))) //50 cog makes you unable to trip
-			if(!our_trippah.back)
-				to_chat(our_trippah, SPAN_WARNING("You would have tripped if you didn't balance."))
+		if(M.stats.getPerk(PERK_KLUTZ) || our_trippah.stats.getStat(STAT_VIG) <= 0) //Negative Vig just makes you faceslam hard. This is equal to rolling uneven number with 1 Hand/Eye Coordination. Klutz is self explanatory
+			if(prob(60))
+				to_chat(our_trippah, SPAN_WARNING("Your poor motorics made you slam hard into the plating!"))
+				our_trippah.adjustBruteLoss(15)
+				our_trippah.trip(src, 6)
 				return
+		if(M.stats.getPerk(PERK_SURE_STEP))//You trip even with this perk if klutz or vig below 0
+			return
+		if(!our_trippah.back)
+			return
+		if(prob(50 - our_trippah.stats.getStat(STAT_VIG))) //50 VIG makes you unable to trip
+			to_chat(our_trippah, SPAN_WARNING("You gently slam into the plating!"))
 			our_trippah.adjustBruteLoss(5)
 			our_trippah.trip(src, 6)
 			return

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/Ploge.dm
@@ -82,7 +82,7 @@
 
 	var/mob/living/carbon/human/H = target
 	if(istype(H))
-		if(prob(100 - H.stats.getStat(STAT_VIG)))
+		if(prob(100 - H.stats.getStat(STAT_COG))) // Mental
 			H.Weaken(4)
 			to_chat(H, SPAN_WARNING("A horrifying roar of primal soul-less terror sears through your mind!"))
 		else

--- a/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoRobust.dm
+++ b/code/modules/mob/living/carbon/superior_animal/xenomorph/types/XenoRobust.dm
@@ -73,7 +73,7 @@ var/datum/xenomorph/xeno_morph_ai
 
 	var/mob/living/carbon/human/H = target
 	if(istype(H))
-		if(prob(100 - H.stats.getStat(STAT_VIG)))
+		if(prob(100 - H.stats.getStat(STAT_COG))) // Mental attack
 			H.Weaken(4)
 			to_chat(H, SPAN_WARNING("A horrifying roar of primal soul-less terror sears through your mind!"))
 		else

--- a/code/modules/mob/living/simple_animal/hostile/bear.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bear.dm
@@ -40,7 +40,7 @@
 		playsound(src, 'sound/effects/creatures/bear.ogg', 100, 1, -3)
 		for(var/mob/living/carbon/human/H in range(5,src))
 			if(istype(H))
-				if(prob(100 - H.stats.getStat(STAT_VIG))) //Kinda a hard check-ish but cant stack
+				if(prob(100 - H.stats.getStat(STAT_COG))) //Kinda a hard check-ish but cant stack
 					H.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT, 30 SECONDS, "fear_of_bear")
 					H.stats.addTempStat(STAT_COG, -STAT_LEVEL_ADEPT, 30 SECONDS, "fear_of_bear")
 					H.stats.addTempStat(STAT_BIO, -STAT_LEVEL_ADEPT, 30 SECONDS, "fear_of_bear")

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -156,16 +156,16 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 	activate_mobs_in_range(owner, SANITY_MOB_DISTANCE_ACTIVATION)
 	if(sanity_invulnerability)//Sorry, but that needed to be added here :C
 		return
-	var/vig = owner.stats.getStat(STAT_VIG)
+	var/cog = owner.stats.getStat(STAT_COG)
 	for(var/atom/A in view(owner.client ? owner.client : owner))
 		if(A.sanity_damage) //If this thing is not nice to behold
-			. += SANITY_DAMAGE_VIEW(A.sanity_damage, vig, get_dist(owner, A))
+			. += SANITY_DAMAGE_VIEW(A.sanity_damage, cog, get_dist(owner, A))
 
 		if(owner.stats.getPerk(PERK_IDEALIST) && ishuman(A)) //Moralists react negatively to people in distress
 			var/mob/living/carbon/human/H = A
 			if(H.sanity.level < 30 || H.health < 50)
-				. += SANITY_DAMAGE_VIEW(0.1, vig, get_dist(owner, A))
-
+				. += SANITY_DAMAGE_VIEW(0.1, cog, get_dist(owner, A))
+// Hold yourself together. Keep your Morale up.
 
 /datum/sanity/proc/handle_area()
 	var/area/my_area = get_area(owner)
@@ -173,7 +173,7 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 		return 0
 	. = my_area.sanity.affect
 	if(. < 0)
-		. *= owner.stats.getStat(STAT_VIG) / STAT_LEVEL_MAX
+		. *= owner.stats.getStat(STAT_COG) / STAT_LEVEL_MAX //Mental state should matter more than your perception and agility
 
 /datum/sanity/proc/handle_breakdowns()
 	for(var/datum/breakdown/B in breakdowns)
@@ -403,15 +403,15 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 	owner.pick_individual_objective()
 
 /datum/sanity/proc/onDamage(amount)
-	changeLevel(-SANITY_DAMAGE_HURT(amount, owner.stats.getStat(STAT_VIG)))
+	changeLevel(-SANITY_DAMAGE_HURT(amount, owner.stats.getStat(STAT_COG)))
 
 /datum/sanity/proc/onPsyDamage(amount)
-	changeLevel(-SANITY_DAMAGE_PSY(amount, owner.stats.getStat(STAT_VIG)))
+	changeLevel(-SANITY_DAMAGE_PSY(amount, owner.stats.getStat(STAT_COG)))
 
 /datum/sanity/proc/onSeeDeath(mob/M)
 	var/mob/living/carbon/human/H
 	if(ishuman(H))
-		var/penalty = -SANITY_DAMAGE_DEATH(owner.stats.getStat(STAT_VIG))
+		var/penalty = -SANITY_DAMAGE_DEATH(owner.stats.getStat(STAT_COG))
 		if(owner.stats.getPerk(PERK_NIHILIST))
 			var/effect_prob = rand(1, 100)
 			switch(effect_prob)
@@ -423,13 +423,13 @@ GLOBAL_VAR_INIT(GLOBAL_INSIGHT_MOD, 1)
 					penalty *= -1
 				if(75 to 100)
 					penalty *= 0
-		if(M.stats.getPerk(PERK_TERRIBLE_FATE) && prob(100-owner.stats.getStat(STAT_VIG)))
+		if(M.stats.getPerk(PERK_TERRIBLE_FATE) && prob(100-owner.stats.getStat(STAT_COG)))
 			setLevel(0)
 		else
 			changeLevel(penalty*death_view_multiplier)
 
 /datum/sanity/proc/onShock(amount)
-	changeLevel(-SANITY_DAMAGE_SHOCK(amount, owner.stats.getStat(STAT_VIG)))
+	changeLevel(-SANITY_DAMAGE_SHOCK(amount, owner.stats.getStat(STAT_COG)))
 
 /datum/sanity/proc/onAlcohol(datum/reagent/ethanol/E, multiplier)
 	changeLevel(E.sanity_gain_ingest * multiplier)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Complicates the underplating code for no reason with making it so while lying down or getting dragged while knocked out it no longer damages you, Klutz and negative vigilance also have way higher debuff now and Klutz no longer stacks with Sure Step for purposes of ignoring underplating as you are still a klutz. It also now accounts for Vigilance again instead of Cognition but this will make sense right after this.
Examining footsteps is based on cognition now instead of vigilance, plain reason not only vigilance does too much but being smart would help you way more in deducing crime and details than just being plain perceptive.
Santy checks now fully rely on Cognition, not Vigilance, as the one before, vigilance is measurment of your agility, perception and hand/eye coordination, not your mental fortitude. Besides this Vigilance already does so much and Cognition for longest time was considered a dump stat for it's only real use being found in the crafting and scrapping departments, this should hopefully finally make it way more desirable.

https://tenor.com/view/harrier-du-bois-disco-elysium-sphere-harrier-du-balls-rotate-gif-26557474
	
<hr>
</details>

## Changelog
:cl:
balance: Cognition vs Vigilance
fix: Bad logic on underplate tripping
/:cl:
