### PR TITLE
borg syringe fix

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -123,7 +123,7 @@
 	desc = "A refrigerated storage unit for medicine and chemical storage."
 
 /obj/machinery/smartfridge/chemistry/accept_check(var/obj/item/O as obj)
-	if(istype(O,/obj/item/storage/pill_bottle) || istype(O,/obj/item/reagent_containers))
+	if(istype(O,/obj/item/storage/pill_bottle) || (istype(O,/obj/item/reagent_containers) && !istype(O,/obj/item/reagent_containers/borghypo) && !istype(O,/obj/item/reagent_containers/syringe/blitzshell)))
 		return 1
 	return 0
 


### PR DESCRIPTION
Stops medi borgs from putting their syringes in the fridge.


(Didn't spend to much time testing this one. I couldn't get the medical syringe to go into the fridge I spawned in.)
