### PR TITLE
Perk perkinson

### DIFF
--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -296,7 +296,7 @@
 
 /datum/perk/second_skin
 	name = "Second Skin"
-	desc = "Cindarites, be they bunker born or spacers, are used to wearing bulky enviromental suits. This life time of being acclimated to heavy clothing has become a second skin for many, allowing you to remove clothing instantly and never suffer slowdown from heavy armor."
+	desc = "Cindarites, be they bunker born or spacers, are used to wearing bulky enviromental suits. This life time of being acclimated to heavy clothing has become a second skin for many, allowing you to remove clothing instantly and only suffer half the slowdown from heavy armor."
 
 ///////////////////////////////////////////Opifex perks
 /datum/perk/opifex_backup

--- a/code/datums/setup_option/backgrounds/origin_career.dm
+++ b/code/datums/setup_option/backgrounds/origin_career.dm
@@ -5,7 +5,7 @@
 	(or dishonest) citizen of the colony. One benefit at least of your raider life style is you got good at getting in and out quickly, regardless of any barriers in your way. Sadly your past is \
 	a known factor and while here on the frontier security can overlook a checkered past, your records should contain a detailed and accurate report of your history."
 
-	perks = list(PERK_PARKOUR )
+	perks = list(PERK_PARKOUR)
 
 	stat_modifiers = list(
 		STAT_ROB = 0,

--- a/code/datums/setup_option/backgrounds/origin_kriosan.dm
+++ b/code/datums/setup_option/backgrounds/origin_kriosan.dm
@@ -7,6 +7,8 @@
 
 	restricted_to_species = list(FORM_KRIOSAN)
 
+	perks = list(PERK_BOLT_REFLECT)
+
 	stat_modifiers = list(
 		STAT_ROB = 0,
 		STAT_TGH = 0,
@@ -25,6 +27,8 @@
 	day."
 
 	restricted_to_species = list(FORM_KRIOSAN)
+
+	perks = list(PERK_PERFECT_SHOT)
 
 	stat_modifiers = list(
 		STAT_ROB = 5,

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -44,6 +44,8 @@
 		//Not porting bay's silly organ checking code here
 		tally += 1 //Small slowdown so wheelchairs aren't turbospeed
 	else
+		if(wear_suit && src.stats.getPerk(PERK_SECOND_SKIN))
+			tally += wear_suit.slowdown/2
 		if(wear_suit && !src.stats.getPerk(PERK_SECOND_SKIN))
 			tally += wear_suit.slowdown
 		if(shoes)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -251,7 +251,7 @@
 	taste_sensitivity = TASTE_HYPERSENSITIVE
 	hunger_factor = 1.25
 	radiation_mod = 0.5
-	total_health = 150
+	total_health = 130
 	siemens_coefficient = 2
 
 	dark_color = "#ff0000"
@@ -292,7 +292,7 @@
 		)
 	permitted_wings = list()
 
-	perks = list(PERK_PERFECT_SHOT, PERK_ENHANCEDSENSES)
+	perks = list(PERK_ENHANCEDSENSES)
 
 /datum/species/kriosan/get_bodytype()
 	return "Kriosan"
@@ -312,6 +312,7 @@
 	blurb = "no."
 	taste_sensitivity = TASTE_DULL
 	hunger_factor = 1.25
+	total_health = 120
 
 	cold_level_1 = 240 //Default 270
 	cold_level_2 = 200 //Default 230
@@ -352,7 +353,7 @@
 	name_language = null
 	min_age = 18
 	max_age = 60
-	slowdown = -0.5
+	slowdown = -0.4
 	blurb = "no."
 	darksight = 2
 
@@ -521,7 +522,7 @@
 	min_age = 18
 	max_age = 90
 	spawn_flags = CAN_JOIN
-	total_health = 130                    // Burn damage multiplier.
+	total_health = 110                   // Burn damage multiplier.
 	radiation_mod = 0
 	darksight = 3
 

--- a/code/modules/reagents/reagents/race.dm
+++ b/code/modules/reagents/reagents/race.dm
@@ -52,7 +52,7 @@
 	M.add_chemical_effect(CE_TOXIN, -1)
 	M.add_chemical_effect(CE_BLOODCLOT, 0.4)
 	M.add_chemical_effect(CE_BLOODRESTORE, 1.1 * effect_multiplier) // Paramount due to how organ efficiency works
-	M.add_chemical_effect(CE_PAINKILLER, 45, TRUE) // Come on, stand up! You can do it!
+	M.add_chemical_effect(CE_PAINKILLER, 30, TRUE) // Come on, stand up! You can do it!
 	M.add_chemical_effect(CE_STABLE)
 
 /datum/reagent/stim/kriotol
@@ -63,14 +63,17 @@
 	reagent_state = LIQUID
 	color = "#5f95e2"
 	nerve_system_accumulations = 0
+	addiction_chance = 100
 	appear_in_default_catalog = FALSE
 
 /datum/reagent/stim/kriotol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.stats.addTempStat(STAT_TGH, 10, STIM_TIME, "kriotol")
-	M.stats.addTempStat(STAT_VIG, 20, STIM_TIME, "kriotol")
+	M.stats.addTempStat(STAT_VIG, 30, STIM_TIME, "kriotol")
 	M.add_chemical_effect(CE_DARKSIGHT, SEE_INVISIBLE_NOLIGHTING)
-	M.add_chemical_effect(CE_SPEEDBOOST, 0.2)
 	M.add_chemical_effect(CE_PULSE, 2)
+
+/datum/reagent/drug/robustitol/withdrawal_act(mob/living/carbon/M)
+	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "kriotol_w")
+	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT, STIM_TIME, "kriotol_w") //Just peaked in performance, go calm down just like the other aliens
 
 /datum/reagent/stim/robustitol
 	name = "Robustitol"
@@ -85,15 +88,16 @@
 
 /datum/reagent/stim/robustitol/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.stats.addTempStat(STAT_TGH, 60, STIM_TIME, "robustitol")
-	M.stats.addTempStat(STAT_ROB, 60, STIM_TIME, "robustitol")
-	M.stats.addTempStat(STAT_COG, -100, STIM_TIME, "robustitol")
-	M.stats.addTempStat(STAT_BIO, -100, STIM_TIME, "robustitol")
-	M.stats.addTempStat(STAT_VIG, -100, STIM_TIME, "robustitol")
-	M.stats.addTempStat(STAT_MEC, -100, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_ROB, 80, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_COG, -80, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_BIO, -80, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_VIG, -60, STIM_TIME, "robustitol")
+	M.stats.addTempStat(STAT_MEC, -80, STIM_TIME, "robustitol")
+	M.add_chemical_effect(CE_PAINKILLER, 100, TRUE) //All consuming rage but still somehow feels pain ?
 
 /datum/reagent/drug/robustitol/withdrawal_act(mob/living/carbon/M)
 	M.stats.addTempStat(STAT_TGH, -STAT_LEVEL_BASIC, STIM_TIME, "robustitol_w")
-	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_BASIC, STIM_TIME, "robustitol_w")
+	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_ADEPT, STIM_TIME, "robustitol_w")
 
 /datum/reagent/medicine/sergatonin
 	name = "Naratonin"
@@ -103,15 +107,17 @@
 	reagent_state = LIQUID
 	color = "#FF3300"
 	nerve_system_accumulations = 0
+	addiction_chance = 100
 	appear_in_default_catalog = FALSE
 	constant_metabolism = TRUE
 	scannable = TRUE
 
 /datum/reagent/medicine/sergatonin/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	M.stats.addTempStat(STAT_TGH, 25, STIM_TIME, "naratonin")
-	M.stats.addTempStat(STAT_ROB, 25, STIM_TIME, "naratonin")
 	M.add_chemical_effect(CE_SPEEDBOOST, 0.6)
 	M.add_chemical_effect(CE_PULSE, 2)
+
+/datum/reagent/drug/robustitol/withdrawal_act(mob/living/carbon/M)
+	M.add_chemical_effect(CE_SPEEDBOOST, -0.4)
 
 /datum/reagent/medicine/spaceacillin/cindicillin
 	name = "Cindicillin"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Finally splits the perfect shot from all kriosans to just vorhut and gives jaeger bolting perk, second skin now only halves armor slowdown instead of entirely removing it.
Kriosan and Naramad boosts now have withdrawal effects just like akula and had what they do changed, akula perk now actually gives painkiller again after long 2 years and other smaller changes to keep the aliens bit in line with themselves rather than humans
	
<hr>
</details>

## Changelog
:cl:
balance: Alien perks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
