### PR TITLE
The slimes are in* (*not entirely, but playable)

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -156,10 +156,8 @@
 #define PERK_SLIME_FOLLOWER /datum/perk/racial/mycus_slime
 
 //Slime
-#define PERK_SPEED /datum/perk/racial/slime_speed
-#define PERK_LIMB_REGEN /datum/perk/racial/slime_regen
-#define PERK_MIND_BOOST /datum/perk/racial/slime_stat_boost/mental
-#define PERK_BODY_BOOST /datum/perk/racial/slime_stat_boost/physical
+#define PERK_LIMB_REGEN /datum/perk/racial/limb_regen
+#define PERK_SLIMEBODY /datum/perk/slime_metabolism
 
 //////////////
 //Core Perks//

--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -157,7 +157,7 @@
 
 //Slime
 #define PERK_LIMB_REGEN /datum/perk/racial/limb_regen
-#define PERK_SLIMEBODY /datum/perk/slime_metabolism
+#define PERK_SLIMEBODY /datum/perk/racial/slime_metabolism
 
 //////////////
 //Core Perks//

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -656,6 +656,8 @@
 	for(var/obj/item/organ/external/current_organ in holder.organs) //grab the current brute/burn of the limb, then re-apply half of it after rejuvenating OR subtract ten, whichever is lower
 		var/old_brute = current_organ.brute_dam
 		var/old_burn = current_organ.burn_dam
+		if(!(current_organ == BP_HEAD))
+			current_organ.replaced()
 		current_organ.rejuvenate()
 		current_organ.brute_dam = max(0, min((old_brute / 2), (old_brute - 10)))
 		current_organ.burn_dam = max(0, min((old_burn / 2), (old_burn - 10)))

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -640,64 +640,35 @@
 	..()
 
 ///////////////////////////////////// Slime perks
-/datum/perk/racial/slime_speed
-	name = "Gelatinous speed"
-	desc = "Increase your speed for a short amount of time."
-	var/cooldown = 10 MINUTES
-	passivePerk = FALSE
-	var/nutrition_cost = 100
-
-/datum/perk/racial/slime_speed/activate()
-	if(world.time < cooldown_time)
-		to_chat(usr, SPAN_NOTICE("TODO Error Message"))
-		return FALSE
-	cooldown_time = world.time + cooldown
-
-	holder.nutrition -= nutrition_cost
-	// TODO : Add Speedy Chemical Injection here -R4d6
-
-/datum/perk/racial/slime_regen
+/datum/perk/limb_regen
 	name = "Gelatinous Regeneration"
-	desc = "Spend nutrition in exchange of regenerating your limbs"
+	desc = "Spend nutrition to regenerate lost limbs, albeit without fully fixing your injuries."
 	var/cooldown = 30 MINUTES
 	passivePerk = FALSE
-	var/nutrition_cost = 500 // I don't know if nutrition even goes that high, but that's Possum's problem. -R4d6
-	var/list/limbs = list(BP_HEAD, BP_GROIN, BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
+	var/nutrition_cost = 300
 
-/datum/perk/racial/slime_regen/activate()
+/datum/perk/limb_regen/activate()
 	if(world.time < cooldown_time)
-		to_chat(usr, SPAN_NOTICE("TODO Error Message"))
+		to_chat(usr, SPAN_NOTICE("You can't regenerate again so soon!"))
 		return FALSE
 	cooldown_time = world.time + cooldown
 	holder.nutrition -= nutrition_cost
-	holder.restore_all_organs() // Function located in 'code/modules/mob/living/carbon/human/human_damage.dm' Line 334. I couldn't find anything better for regenerating missing limbs and I'm too tired to try and code it in, so it will have to do. -R4d6
+	for(var/obj/item/organ/external/current_organ in holder.organs) //grab the current brute/burn of the limb, then re-apply half of it after rejuvenating OR subtract ten, whichever is lower
+		var/old_brute = current_organ.brute_dam
+		var/old_burn = current_organ.burn_dam
+		current_organ.rejuvenate()
+		current_organ.brute_dam = max(0, min((old_brute / 2), (old_brute - 10)))
+		current_organ.burn_dam = max(0, min((old_burn / 2), (old_burn - 10)))
 
-/datum/perk/racial/slime_stat_boost
-	name = "Gelatinous Stat Boost"
-	desc = "Spend nutrition in exchange of \[INSERT DESCRIPTION HERE\]"
-	var/cooldown = 15 MINUTES
-	passivePerk = FALSE
-	var/nutrition_cost = 100
-	var/list/stats_to_boost = list() // Which stats we boost
-	var/amount_to_boost = 90 // How much the stats are boosted
-	var/duration = 0.5 MINUTES // How long the stats are boosted for
+/datum/perk/slime_metabolism
+	name = "Gelatinous Biology"
+	desc = "Your abnormal biology allows you to benefit from most toxins - however, many antitoxins are outright harmful to you." //This perk doesn't actually cause the slime-specific chem metabolism effects
+	passivePerk = TRUE
 
-/datum/perk/racial/slime_stat_boost/activate()
-	if(world.time < cooldown_time)
-		to_chat(usr, SPAN_NOTICE("TODO Error Message"))
-		return FALSE
-	cooldown_time = world.time + cooldown
-	holder.nutrition -= nutrition_cost
-	for(var/I in stats_to_boost)
-		holder.stats.addTempStat(I, amount_to_boost, duration, "Slime Biology")
+/datum/perk/slime_metabolism/assign(mob/living/carbon/human/H)
+	..()
+	holder.toxin_mod_perk -= 0.5
 
-/datum/perk/racial/slime_stat_boost/mental
-	name = "Gelatinous Mental Stat Boost"
-	desc = "Spend nutrition in exchange of \[INSERT DESCRIPTION HERE\]"
-	stats_to_boost = list(STAT_BIO, STAT_MEC, STAT_COG)
-
-/datum/perk/racial/slime_stat_boost/physical
-	name = "Gelatinous Physical Stat Boost"
-	desc = "Spend nutrition in exchange of \[INSERT DESCRIPTION HERE\]"
-	stats_to_boost = list(STAT_ROB, STAT_TGH, STAT_VIG)
-
+/datum/perk/slime_metabolism/better_toxins/remove()
+	holder.toxin_mod_perk += 0.5
+	..()

--- a/code/datums/perks/racial.dm
+++ b/code/datums/perks/racial.dm
@@ -640,14 +640,14 @@
 	..()
 
 ///////////////////////////////////// Slime perks
-/datum/perk/limb_regen
+/datum/perk/racial/limb_regen
 	name = "Gelatinous Regeneration"
 	desc = "Spend nutrition to regenerate lost limbs, albeit without fully fixing your injuries."
 	var/cooldown = 30 MINUTES
 	passivePerk = FALSE
 	var/nutrition_cost = 300
 
-/datum/perk/limb_regen/activate()
+/datum/perk/racial/limb_regen/activate()
 	if(world.time < cooldown_time)
 		to_chat(usr, SPAN_NOTICE("You can't regenerate again so soon!"))
 		return FALSE
@@ -660,15 +660,15 @@
 		current_organ.brute_dam = max(0, min((old_brute / 2), (old_brute - 10)))
 		current_organ.burn_dam = max(0, min((old_burn / 2), (old_burn - 10)))
 
-/datum/perk/slime_metabolism
+/datum/perk/racial/slime_metabolism
 	name = "Gelatinous Biology"
 	desc = "Your abnormal biology allows you to benefit from most toxins - however, many antitoxins are outright harmful to you." //This perk doesn't actually cause the slime-specific chem metabolism effects
 	passivePerk = TRUE
 
-/datum/perk/slime_metabolism/assign(mob/living/carbon/human/H)
+/datum/perk/racial/slime_metabolism/assign(mob/living/carbon/human/H)
 	..()
 	holder.toxin_mod_perk -= 0.5
 
-/datum/perk/slime_metabolism/better_toxins/remove()
+/datum/perk/racial/slime_metabolism/better_toxins/remove()
 	holder.toxin_mod_perk += 0.5
 	..()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -53,7 +53,7 @@
 
 /obj/item/storage/backpack/proc/worn_check(var/no_message = FALSE)
 	var/mob/living/L = loc
-	if(istype(L, /mob/living/carbon/human) && L:species:reagent_tag == IS_SLIME) // Slimes don't have joints.
+	if(istype(L, /mob/living/carbon/human))
 		// TODO, special messages
 		return TRUE
 

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -122,6 +122,9 @@
 	icon = 'icons/mob/slimes.dmi'
 	icon_state = "bluespace slime extract"
 	parent_organ_base = BP_CHEST
+	blood_req = 0
+	max_blood_storage = 0
+	oxygen_req = 0
 	var/regenerating = FALSE
 	var/revival_chem = "plasma"
 	var/respawn_delay = 100 // Delay, in deciseconds (1/10th of a second), before the slime actually revive after being injected.
@@ -131,7 +134,7 @@
 		var/obj/item/reagent_containers/syringe/S = I
 		if(S.mode == 1 && S.reagents.remove_reagent(revival_chem, 5)) // We inject 5u of plasma // the 1 correspond to SYRINGE_INJECT, but we're before the define
 			to_chat(user, SPAN_NOTICE("You inject [revival_chem] into [src]."))
-			src.visible_message("[src] start to wobble and wiggle...")
+			src.visible_message("[src] starts to wobble and wiggle...")
 			regenerating = TRUE
 			spawn(100) regen_body()
 
@@ -141,7 +144,7 @@
 	var/mob/living/carbon/human/host = new(src, FORM_SLIME, FORM_SLIME)
 	brainmob?.mind.transfer_to(host)
 
-	src.visible_message("[src] expand into a humanoid form")
+	src.visible_message("[src] expands into a humanoid form.")
 
 /obj/item/organ/internal/brain/golem
 	name = "scroll"

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -29,6 +29,9 @@
 	var/datum/metabolism_effects/metabolism_effects = null
 	var/losebreath = 0 //if we failed to breathe last tick
 
+	var/always_blood = FALSE //Do we always process reagents as though we have blood?
+	var/always_ingest = FALSE //Do we always process reagents as though we have a stomach?
+
 	var/coughedtime = null
 	var/lastpuke = 0
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -46,4 +46,3 @@
 
 	var/movement_hunger_factors = 1
 	//TODO: move to brain
-

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1645,38 +1645,7 @@ var/list/rank_prefix = list(\
 
 /mob/living/carbon/human/Move(NewLoc, Dir = 0, step_x = 0, step_y = 0, var/glide_size_override = 0)
 	. = ..()
-	if(.)
-		if(species.reagent_tag == IS_SLIME) // Slimes clean the floor. Code stolen from the roombas
-			var/turf/tile = loc
-			var/nutrition_gained = 5 // Up here for ease of modification
-			if(isturf(tile))
-				tile.clean_blood()
-				for(var/A in tile)
-					if(istype(A, /obj/effect))
-						if(istype(A, /obj/effect/decal/cleanable) || istype(A, /obj/effect/overlay))
-							qdel(A)
-							src.nutrition += nutrition_gained // Gain some nutrition
-					else if(istype(A, /obj/item))
-						var/obj/item/cleaned_item = A
-						cleaned_item.clean_blood()
-					else if(ishuman(A))
-						var/mob/living/carbon/human/cleaned_human = A
-						if(cleaned_human.lying)
-							if(cleaned_human.head)
-								cleaned_human.head.clean_blood()
-								cleaned_human.update_inv_head(0)
-							if(cleaned_human.wear_suit)
-								cleaned_human.wear_suit.clean_blood()
-								cleaned_human.update_inv_wear_suit(0)
-							else if(cleaned_human.w_uniform)
-								cleaned_human.w_uniform.clean_blood()
-								cleaned_human.update_inv_w_uniform(0)
-							if(cleaned_human.shoes)
-								cleaned_human.shoes.clean_blood()
-								cleaned_human.update_inv_shoes(0)
-							cleaned_human.clean_blood(1)
-							to_chat(cleaned_human, SPAN_DANGER("[src] cleans your face!"))
-
+//no more slime cleaning
 
 /mob/living/carbon/human/proc/set_remoteview(var/atom/A)
 	remoteview_target = A

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -62,10 +62,6 @@
 		return list(HUMAN_EATING_BLOCKED_MOUTH, blocked)
 	return list(HUMAN_EATING_NO_ISSUE)
 
-#undef HUMAN_EATING_NO_ISSUE
-#undef HUMAN_EATING_NO_MOUTH
-#undef HUMAN_EATING_BLOCKED_MOUTH
-
 /mob/living/carbon/human/proc/update_equipment_vision()
 	flash_protection = 0
 	psi_blocking = 0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -752,6 +752,8 @@
 	return min(1,.)
 
 /mob/living/carbon/human/handle_chemicals_in_body()
+	always_ingest = species.always_ingest
+	always_blood = species.always_blood
 	if(in_stasis)
 		return
 

--- a/code/modules/mob/living/carbon/human/species/forms/station.dm
+++ b/code/modules/mob/living/carbon/human/species/forms/station.dm
@@ -309,7 +309,7 @@
 	base = 'icons/mob/human_races/r_slime.dmi'
 	deform = 'icons/mob/human_races/r_slime.dmi'
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR | HAS_SKIN_COLOR | DEFAULT_APPEARANCE_FLAGS
-	playable = TRUE
+	playable = FALSE
 
 	blood_color = "#05FF9B"
 	flesh_color = "#05FFFB"

--- a/code/modules/mob/living/carbon/human/species/forms/station.dm
+++ b/code/modules/mob/living/carbon/human/species/forms/station.dm
@@ -309,7 +309,7 @@
 	base = 'icons/mob/human_races/r_slime.dmi'
 	deform = 'icons/mob/human_races/r_slime.dmi'
 	appearance_flags = HAS_HAIR_COLOR | HAS_LIPS | HAS_UNDERWEAR | HAS_EYE_COLOR | HAS_SKIN_COLOR | DEFAULT_APPEARANCE_FLAGS
-	playable = FALSE
+	playable = TRUE
 
 	blood_color = "#05FF9B"
 	flesh_color = "#05FFFB"

--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -29,7 +29,9 @@
 
 	var/mob_size	= MOB_MEDIUM
 	var/virus_immune
-	var/blood_volume = 560                               // Initial blood volume.
+	var/blood_volume = 560
+	var/always_blood = FALSE 						 // Can we process reagents without blood?
+	var/always_ingest = FALSE 		                               // Initial blood volume.
 	var/hunger_factor = DEFAULT_HUNGER_FACTOR            // Multiplier for hunger.
 	var/taste_sensitivity = TASTE_NORMAL                 // How sensitive the species is to minute tastes.
 	var/show_ssd = "fast asleep"

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -1124,6 +1124,17 @@
 	toxins_mod = 1 // fuck toxins_mod, we use a perk for this
 	oxy_mod = 0
 
+	cold_discomfort_level = 283
+	heat_discomfort_level = 313
+
+	cold_level_1 = 258 //Default 270
+	cold_level_2 = 243 //Default 230
+	cold_level_3 = 228  //Default 200
+
+	heat_level_1 = 333 //Default 330
+	heat_level_2 = 353 //Default 380
+	heat_level_3 = 372 //Default 460
+
 	has_process = list(
 		BP_BRAIN = /obj/item/organ/internal/brain/slime,
 		)

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -1112,18 +1112,20 @@
 	siemens_coefficient = 3 //conductive
 	darksight = 3
 	virus_immune = TRUE
+	always_blood = TRUE
+	always_ingest = TRUE
 	breath_type = null
 	poison_type = null
 	hunger_factor = 2
-	spawn_flags = IS_RESTRICTED
+	spawn_flags = CAN_JOIN
 
 	burn_mod = 1.15
 	brute_mod = 1.15
-	toxins_mod = -1 // This is dumb. I hope it works. -R4d6
+	toxins_mod = 1 // fuck toxins_mod, we use a perk for this
 	oxy_mod = 0
 
 	has_process = list(
-		BP_BRAIN = /obj/item/organ/internal/brain/slime
+		BP_BRAIN = /obj/item/organ/internal/brain/slime,
 		)
 
 	breath_type = null
@@ -1143,10 +1145,9 @@
 		BP_R_LEG =  new /datum/organ_description/leg/right/slime
 	)
 
-	perks = list(PERK_SPEED, PERK_LIMB_REGEN, PERK_MIND_BOOST, PERK_BODY_BOOST)
+	perks = list(PERK_LIMB_REGEN, PERK_SLIMEBODY)
 
-/datum/species/slime/handle_death(var/mob/living/carbon/human/H)
+/*/datum/species/slime/handle_death(var/mob/living/carbon/human/H)
 	spawn(1)
 		if(H)
-			H.gib()
-
+			H.gib()*/

--- a/code/modules/mob/living/carbon/slime/life.dm
+++ b/code/modules/mob/living/carbon/slime/life.dm
@@ -540,3 +540,30 @@
 
 /mob/living/carbon/slime/slip() //Can't slip something without legs.
 	return 0
+
+//fancy slime people code, because making slime people carbon/human/slime is too much and would totally not solve a bunch of issues
+
+/mob/living/carbon/slime/can_eat(var/food, var/feedback = 1)
+	var/list/status = can_eat_status()
+	if(status[1] == HUMAN_EATING_NO_ISSUE)
+		return 1
+	if(feedback)
+		if(status[1] == HUMAN_EATING_NO_MOUTH)
+			to_chat(src, "Where do you intend to put \the [food]? You don't have a mouth!")
+		else if(status[1] == HUMAN_EATING_BLOCKED_MOUTH)
+			to_chat(src, SPAN_WARNING("\The [status[2]] is in the way!"))
+	return 0
+
+/mob/living/carbon/slime/proc/can_eat_status()
+	return list(HUMAN_EATING_NO_ISSUE)
+
+/mob/living/carbon/slime/can_force_feed(var/feeder, var/food, var/feedback = 1)
+	var/list/status = can_eat_status()
+	if(status[1] == HUMAN_EATING_NO_ISSUE)
+		return 1
+	if(feedback)
+		if(status[1] == HUMAN_EATING_NO_MOUTH)
+			to_chat(feeder, "Where do you intend to put \the [food]? \The [src] doesn't have a mouth!")
+		else if(status[1] == HUMAN_EATING_BLOCKED_MOUTH)
+			to_chat(feeder, SPAN_WARNING("\The [status[2]] is in the way!"))
+	return 0

--- a/code/modules/organs/external/subtypes/slime.dm
+++ b/code/modules/organs/external/subtypes/slime.dm
@@ -1,8 +1,6 @@
 // Slime limbs.
 /obj/item/organ/external/slime
 	nerve_struck = -1
-	brute_mod = 1.15
-	burn_mod = 1.15
 
 /obj/item/organ/external/slime/make_base_internal_organs()
 	if(is_stump(src))

--- a/code/modules/organs/organ_description.dm
+++ b/code/modules/organs/organ_description.dm
@@ -216,6 +216,7 @@
 	default_type = /obj/item/organ/external/slime
 	default_bone_type = /obj/item/organ/internal/bone/slime
 	vital = FALSE
+	functions = BODYPART_REAGENT_INTAKE
 
 /datum/organ_description/arm/left/slime
 	default_type = /obj/item/organ/external/slime

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -101,6 +101,11 @@
 			removed = ingest_met * calculated_buff
 		else
 			removed = (metabolism / 2) * calculated_buff
+		if(consumer.species.always_ingest) //If we bypass the need for a stomach, use 100 (the average efficiency)
+			if(ingest_met)
+				removed = ingest_met * 1
+			else
+				removed = (metabolism / 2) * 1
 	if(touch_met && (location == CHEM_TOUCH))
 		removed = touch_met // This doesn't get a buff , there is no organ that can count for this , really.
 	// on half of overdose, chemicals will start be metabolized faster,
@@ -112,6 +117,11 @@
 				removed = CLAMP(metabolism * volume/(overdose/2) * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 			else
 				removed = CLAMP(metabolism * volume/(REAGENTS_OVERDOSE/2) * consumer.get_blood_circulation()/100 * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+			if(consumer.species.always_blood) //If we bypass the need for a stomach, use 100 (the average efficiency)
+				if(overdose)
+					removed = CLAMP(metabolism * volume/(overdose/2) * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
+				else
+					removed = CLAMP(metabolism * volume/(REAGENTS_OVERDOSE/2) * calculated_buff, metabolism * REAGENTS_MIN_EFFECT_MULTIPLIER, metabolism * REAGENTS_MAX_EFFECT_MULTIPLIER)
 	removed = max(round(removed, 0.01), 0.01)
 	removed = min(removed, volume)
 

--- a/code/modules/reagents/reagents/core.dm
+++ b/code/modules/reagents/reagents/core.dm
@@ -162,9 +162,9 @@
 	id = "holywater"
 
 /datum/reagent/water/holywater/affect_ingest(mob/living/carbon/human/M, alien, effect_multiplier)
-	var/obj/item/implant/core_implant/I = M.get_core_implant(/obj/item/implant/core_implant/cruciform)
 	if(M.species.reagent_tag == IS_SLIME)
 		M.take_organ_damage(0, 2)
+	var/obj/item/implant/core_implant/I = M.get_core_implant(/obj/item/implant/core_implant/cruciform)
 	if(!I && !I.wearer) //Do we have a core implant?
 		return
 	if(!I.active) //Is it active?
@@ -187,8 +187,6 @@
 	return TRUE
 
 /datum/reagent/water/touch_turf(turf/simulated/T)
-	if(M.species.reagent_tag == IS_SLIME)
-		M.take_organ_damage(0, 2)
 	if(!istype(T))
 		return TRUE
 
@@ -235,6 +233,8 @@
 		*/
 
 /datum/reagent/water/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 2)
 	if(isslime(M))
 		var/mob/living/carbon/slime/S = M
 		S.adjustToxLoss(20 * effect_multiplier) // Babies have 150 health, adults have 200; So, 10 units and 13.5
@@ -266,7 +266,6 @@
 
 /datum/reagent/toxin/fuel/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.add_chemical_effect(CE_TOXIN, 2 * (issmall(M) ? effect_multiplier * 2 : effect_multiplier))
-	M.add_chemical_effect(CE_ALCOHOL, 1)
 
 /datum/reagent/toxin/fuel/touch_mob(mob/living/L, var/amount)
 	if(istype(L))

--- a/code/modules/reagents/reagents/core.dm
+++ b/code/modules/reagents/reagents/core.dm
@@ -107,8 +107,14 @@
 		M.heal_organ_damage(0.3 * effect_multiplier, 0.3 * effect_multiplier)
 		M.add_chemical_effect(CE_ANTITOX, 0.3 * effect_multiplier)
 		M.add_chemical_effect(CE_BLOODCLOT, 0.1)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 1 * effect_multiplier)
 	if(!ishuman(M))
 		M.adjustHalLoss(-0.5)
+
+/datum/reagent/water/affect_blood(var/mob/living/carbon/M, var/alien)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 2)
 
 /datum/reagent/water/extinguisher
 	name = "Extinguisher"
@@ -137,6 +143,17 @@
 	T.color = "white"
 	return TRUE
 
+/datum/reagent/water/extinguisher/affect_ingest(mob/living/carbon/M, alien, effect_multiplier)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 1 * effect_multiplier)
+
+/datum/reagent/water/extinguisher/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 1 * effect_multiplier)
+
+/datum/reagent/water/extinguisher/affect_blood(var/mob/living/carbon/M, var/alien)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 2)
 
 /datum/reagent/water/holywater
 	name = "Holy Water"
@@ -146,12 +163,22 @@
 
 /datum/reagent/water/holywater/affect_ingest(mob/living/carbon/human/M, alien, effect_multiplier)
 	var/obj/item/implant/core_implant/I = M.get_core_implant(/obj/item/implant/core_implant/cruciform)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 2)
 	if(!I && !I.wearer) //Do we have a core implant?
 		return
 	if(!I.active) //Is it active?
 		return
 	M.heal_organ_damage(0, 0.2 * effect_multiplier, 0, 3 * effect_multiplier)
 	..()
+
+/datum/reagent/water/holywater/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 1 * effect_multiplier)
+
+/datum/reagent/water/holywater/affect_blood(var/mob/living/carbon/M, var/alien)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 2)
 
 /datum/reagent/water/holywater/touch_turf(turf/T)
 	..()
@@ -160,6 +187,8 @@
 	return TRUE
 
 /datum/reagent/water/touch_turf(turf/simulated/T)
+	if(M.species.reagent_tag == IS_SLIME)
+		M.take_organ_damage(0, 2)
 	if(!istype(T))
 		return TRUE
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -40,7 +40,7 @@
 	nerve_system_accumulations = 15 // Basic chems shouldn't hurt the body as much as higher potency ones.
 
 /datum/reagent/medicine/bicaridine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	if(M.species?.reagent_tag == IS_CHTMANT)
+	if(M.species?.reagent_tag == IS_CHTMANT || M.species?.reagent_tag == IS_SLIME)
 		M.heal_organ_damage(0.15 * effect_multiplier, 0, 5 * effect_multiplier)
 		return
 	M.heal_organ_damage(0.3 * effect_multiplier, 0, 5 * effect_multiplier)
@@ -74,8 +74,9 @@
 	nerve_system_accumulations = 20
 
 /datum/reagent/medicine/varceptol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
+	if(!(M.species?.reagent_tag == IS_SLIME))
+		M.add_chemical_effect(CE_ANTITOX, 3 * removed)
 	M.heal_organ_damage(9 * removed, 0)
-	M.add_chemical_effect(CE_ANTITOX, 3 * removed)
 
 /datum/reagent/medicine/meralyne
 	name = "Meralyne"
@@ -105,7 +106,7 @@
 	nerve_system_accumulations = 10
 
 /datum/reagent/medicine/kelotane/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	if(M.species?.reagent_tag == IS_CHTMANT)
+	if(M.species?.reagent_tag == IS_CHTMANT || M.species?.reagent_tag == IS_SLIME)
 		return
 	M.heal_organ_damage(0, 0.6 * effect_multiplier, 0, 3 * effect_multiplier)
 
@@ -136,6 +137,9 @@
 	nerve_system_accumulations = 0
 
 /datum/reagent/medicine/dylovene/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	if(M.species?.reagent_tag == IS_SLIME)
+		M.add_chemical_effect(CE_TOXIN, 1)
+		return
 	M.drowsyness = max(0, M.drowsyness - 0.6 * effect_multiplier)
 	M.adjust_hallucination(-0.9 * effect_multiplier)
 	M.add_chemical_effect(CE_ANTITOX, 2)
@@ -161,6 +165,9 @@
 	nerve_system_accumulations = -10
 
 /datum/reagent/medicine/carthatoline/affect_blood(var/mob/living/carbon/M, var/alien, effect_multiplier, var/removed = REM)
+	if(M.species?.reagent_tag == IS_SLIME)
+		M.add_chemical_effect(CE_TOXIN, 1.5)
+		return
 	M.add_chemical_effect(CE_ANTITOX, 3 * removed)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
@@ -283,6 +290,8 @@
 /datum/reagent/medicine/tricordrazine/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.species?.reagent_tag == IS_CHTMANT)
 		return
+	if(!(M.species?.reagent_tag == IS_SLIME))
+		M.add_chemical_effect(CE_ANTITOX, 1)
 	M.adjustOxyLoss(-0.6 * effect_multiplier)
 	M.heal_organ_damage(0.3 * effect_multiplier, 0.3 * effect_multiplier)
 	M.add_chemical_effect(CE_ANTITOX, 1)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -25,7 +25,7 @@
 			var/mob/living/carbon/human/H = M
 			H.sanity.onToxin(src, effect_multiplier)
 			M.sanity.onToxin(src, multi)*/
-		if(M.species.reagent_tag == IS_SLIME)
+		if(M.species?.reagent_tag == IS_SLIME)
 			M.adjustNutrition(strength)
 			M.heal_organ_damage(0.1 * strength, 0.1 * strength)
 			M.add_chemical_effect(CE_ANTITOX, 0.3)
@@ -35,7 +35,7 @@
 
 /datum/reagent/toxin/overdose(mob/living/carbon/M, alien)
 	if(strength)
-		if(M.species.reagent_tag == IS_SLIME)
+		if(M.species?.reagent_tag == IS_SLIME)
 			M.adjustNutrition(strength / 2)
 			M.heal_organ_damage(0.05 * strength, 0.05 * strength)
 			M.add_chemical_effect(CE_ANTITOX, 0.1)

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -25,12 +25,22 @@
 			var/mob/living/carbon/human/H = M
 			H.sanity.onToxin(src, effect_multiplier)
 			M.sanity.onToxin(src, multi)*/
-		M.add_chemical_effect(CE_TOXIN, strength)
+		if(M.species.reagent_tag == IS_SLIME)
+			M.adjustNutrition(strength)
+			M.heal_organ_damage(0.1 * strength, 0.1 * strength)
+			M.add_chemical_effect(CE_ANTITOX, 0.3)
+		else
+			M.add_chemical_effect(CE_TOXIN, strength)
 
 
 /datum/reagent/toxin/overdose(mob/living/carbon/M, alien)
 	if(strength)
-		M.add_chemical_effect(CE_TOXIN, strength * dose / 4)
+		if(M.species.reagent_tag == IS_SLIME)
+			M.adjustNutrition(strength / 2)
+			M.heal_organ_damage(0.05 * strength, 0.05 * strength)
+			M.add_chemical_effect(CE_ANTITOX, 0.1)
+		else
+			M.add_chemical_effect(CE_TOXIN, strength * dose / 4)
 
 /datum/reagent/toxin/plasticide
 	name = "Plasticide"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>

- 	not really in, reagents snowflake code needs to be discussed, simply inverting the tox_mod seems like a surefire way to guarantee it will work
- currently there is a runtime in reagents because of the snowflake code
- this pr requires TESTERS, specially people good at mobcode
- needs input on the perks, to keep them aligned with the others (lamas moment)

</summary>
<hr>

- [x] make sure slimes ain't cleaning the floor as they pass
- [x] make sure reagents are working as intended
- [x] make sure perks work as intended
- [x] make sure they can access duffle bags in their backs
- [ ] all that snowflake code about revival
- [x] eating and the whole nutrition thing
- [x] do slimes bleed? is it handled diffeerently?
- [ ] make them partially transparent
- [ ] ancestry (?!?!?!?) it's all WIP

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
add: slime people
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
