### PR TITLE
Corrects bullets in Fontaine lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/fontaine.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/fontaine.dm
@@ -53,8 +53,8 @@
 				new /obj/item/ammo_magazine/highcap_pistol_35(src)
 		if("REVOLVER")
 			new /obj/item/gun/projectile/revolver/frontier(src)
-			new /obj/item/ammo_magazine/speed_loader_pistol_35(src)
-			new /obj/item/ammo_magazine/speed_loader_pistol_35(src)
+			new /obj/item/ammo_magazine/speed_loader_magnum_40(src)
+			new /obj/item/ammo_magazine/speed_loader_magnum_40(src)
 		if("EGUN_P")
 			new /obj/item/gun/energy/ntpistol(src)
 			new /obj/random/powercell/small_safe_lonestar(src)
@@ -143,8 +143,8 @@
 				new /obj/item/ammo_magazine/highcap_pistol_35(src)
 		if("REVOLVER")
 			new /obj/item/gun/projectile/revolver/frontier(src)
-			new /obj/item/ammo_magazine/speed_loader_pistol_35(src)
-			new /obj/item/ammo_magazine/speed_loader_pistol_35(src)
+			new /obj/item/ammo_magazine/speed_loader_magnum_40(src)
+			new /obj/item/ammo_magazine/speed_loader_magnum_40(src)
 
 	//melee
 	switch(melee_cache)


### PR DESCRIPTION
Fontaine lockers spawning revolver sidearms gave 9mm speedloaders, but the revolver it spawns uses 10mm, sets the speedloaders to 10mm instead.
