### PR TITLE
Fontaine clothes adjustments

### DIFF
--- a/code/datums/outfits/jobs/prospector.dm
+++ b/code/datums/outfits/jobs/prospector.dm
@@ -1,6 +1,7 @@
 /decl/hierarchy/outfit/job/shepherd
 	name = OUTFIT_JOB_NAME("Fontaine Heavy Industries - Field Shepherd")
 	uniform = /obj/item/clothing/under/turtleneck/fontaine
+	head = /obj/item/clothing/head/helmet/shepherd
 	suit = /obj/item/clothing/suit/armor/shepherd
 	glasses = /obj/item/clothing/glasses/sunglasses/fontaine
 	gloves = /obj/item/clothing/gloves/thick/fontaine
@@ -12,6 +13,7 @@
 /decl/hierarchy/outfit/job/trapper
 	name = OUTFIT_JOB_NAME("Fontaine Heavy Industries - Trapper")
 	uniform = /obj/item/clothing/under/turtleneck/fontaine/trapper
+	head = /obj/item/clothing/head/trapper
 	suit = /obj/item/clothing/suit/greatcoat/trapper
 	glasses = /obj/item/clothing/glasses/sunglasses/esquimal
 	gloves = /obj/item/clothing/gloves/thick/fontaine
@@ -23,6 +25,7 @@
 /decl/hierarchy/outfit/job/shipbreaker
 	name = OUTFIT_JOB_NAME("Fontaine Heavy Industries - Shipbreaker")
 	uniform = /obj/item/clothing/under/turtleneck/fontaine
+	head = /obj/item/clothing/head/helmet/handmade/scavengerhelmet
 	suit = /obj/item/clothing/suit/storage/scavengerarmor
 	glasses = /obj/item/clothing/glasses/sunglasses/fontaine
 	gloves = /obj/item/clothing/gloves/thick/fontaine

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -454,8 +454,8 @@
 /obj/item/clothing/head/helmet/shepherd
 	name = "Field Shepherd helmet"
 	desc = "A study, handcrafted helmet reinforced with lightweight material and an added line down its center, depicting that of a Shepherd; herding his employees."
-	icon_state = "shepherd_helmet"
-	item_state = "shepherd_helmet"
+	icon_state = "shepherd_visor"
+	item_state = "shepherd_visor"
 	matter = list(MATERIAL_PLASTEEL = 12, MATERIAL_PLASTIC = 10, MATERIAL_STEEL = 30, MATERIAL_SILVER = 12) //worth stealing
 	price_tag = 1200
 	armor_list = list(

--- a/code/modules/clothing/suits/fontaine.dm
+++ b/code/modules/clothing/suits/fontaine.dm
@@ -70,8 +70,8 @@
 	blood_overlay_type = "coat"
 	permeability_coefficient = 0.50
 	max_upgrades = 2
-	body_parts_covered = UPPER_TORSO|ARMS
-	cold_protection = UPPER_TORSO|ARMS
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
+	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	min_cold_protection_temperature = T0C - 20
 	siemens_coefficient = 0.7
 	armor_list = list( //thicker material so +5 boost (from base 10) to armor values, but lower rad/same bomb since not metal lined. Maybe add in minor slowdown if needed -Dongels


### PR DESCRIPTION
- Adds Fontaine's helmets in-game by adding them to their jobs' roundstart clothes
- Corrects Shepherd helmet spritepath
- Adds Lower Body coverage to the Trapper greatcoat since it only covered upper body and that's a bit silly when even vests reach the Lower Body, arguably it should cover the legs too but SHRUG.

Ready for review, someone else is handling the erroneous female sprites for the clothes.