### PR TITLE
fixes erroneous paths

### DIFF
--- a/code/game/objects/items/weapons/storage/hardcases.dm
+++ b/code/game/objects/items/weapons/storage/hardcases.dm
@@ -723,7 +723,7 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 		options["Specialist - 9mm SMG"] = list(/obj/item/gun/projectile/automatic/specialist,/obj/item/ammo_magazine/smg_35,/obj/item/ammo_magazine/smg_35,/obj/item/ammo_magazine/smg_35)
 		options["Umbani - 10mm SMG"] = list(/obj/item/gun/projectile/automatic/umbani,/obj/item/ammo_magazine/smg_magnum_40,/obj/item/ammo_magazine/smg_magnum_40,/obj/item/ammo_magazine/smg_magnum_40)
 		options["Judge - automatic shotgun"] = list(/obj/item/gun/projectile/shotgun/judge,/obj/item/ammo_magazine/ammobox/shotgun/scrap_pellet,/obj/item/ammo_magazine/speed_loader_shotgun/empty,/obj/item/ammo_magazine/speed_loader_shotgun/empty)
-		options["Big Game - boltaction w/ scope"] = list(/obj/item/gun/projectile/boltgun/gamer, /obj/item/ammo_magazine/speed_loader_light_rifle_257, /obj/item/ammo_magazine/speed_loader_light_rifle_257, /obj/item/ammo_magazine/speed_loader_light_rifle_257, /obj/item/gun_upgrade/scope/acog)
+		options["Big Game - boltaction w/ scope"] = list(/obj/item/gun/projectile/boltgun/gamer, /obj/item/ammo_magazine/speed_loader_rifle_75, /obj/item/ammo_magazine/speed_loader_rifle_75, /obj/item/ammo_magazine/speed_loader_rifle_75, /obj/item/gun_upgrade/scope/acog)
 		options["Cog - energy carbine"] = list(/obj/item/gun/energy/cog, /obj/item/cell/medium, /obj/item/cell/medium, /obj/item/cell/medium)
 		var/choice = input(user,"What type of equipment?") as null|anything in options
 		if(src && choice)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -50,7 +50,7 @@
 		new /obj/item/ammo_magazine/speed_loader_pistol_35(src)
 		new /obj/item/ammo_magazine/speed_loader_pistol_35(src)
 	else
-		new /obj/item/gun/projectile/revolver(src)
+		new /obj/item/gun/projectile/revolver/frontier(src)
 		new /obj/item/ammo_magazine/speed_loader_magnum_40(src)
 		new /obj/item/ammo_magazine/speed_loader_magnum_40(src)
 	if(prob(75))


### PR DESCRIPTION
Fixes the shepherd primary selection giving the wrong ammo.

Fixes the debug revolver spawning in cargo tech lockers, replaced by the Frontier revolver which is still 10mm Magnum as the ammo indicated.