### PR TITLE
medicinal flora and a few things

### DIFF
--- a/code/game/objects/structures/flora/tree/flora_snowtree.dm
+++ b/code/game/objects/structures/flora/tree/flora_snowtree.dm
@@ -7,37 +7,37 @@
 	desc = "A tall tree with a bed of snow over its branches."
 	shadow_overlay = "shadow_overlay1"
 	icon_state = "tree1"
-	pixel_x = -45
-	pixel_y = -16
+	pixel_x = -32
+	pixel_y = 5
 
 /obj/structure/flora/tree/snow/two
 	name = "tree"
 	desc = "A thick trunk of a froozen and dead tree."
 	shadow_overlay = "shadow_overlay2"
 	icon_state = "tree2"
-	pixel_x = -45
-	pixel_y = -16
+	pixel_x = -25
+	pixel_y = 5
 
 /obj/structure/flora/tree/snow/three
 	name = "pine tree"
 	desc = "A tall green needley tree with layers of snow."
 	shadow_overlay = "shadow_overlay3"
 	icon_state = "tree3"
-	pixel_x = -45
-	pixel_y = -16
+	pixel_x = -32
+	pixel_y = 5
 
 /obj/structure/flora/tree/snow/four
 	name = "pine tree"
 	desc = "A short green needley tree with layers of snow."
 	shadow_overlay = "shadow_overlay4"
 	icon_state = "tree4"
-	pixel_x = -45
-	pixel_y = -16
+	pixel_x = -35
+	pixel_y = 5
 
 /obj/structure/flora/tree/snow/five
 	name = "pine tree"
 	desc = "A tall green needley tree with a singluar blanket of snow."
 	shadow_overlay = "shadow_overlay5"
 	icon_state = "tree5"
-	pixel_x = -45
-	pixel_y = -16
+	pixel_x = -32
+	pixel_y = 5

--- a/maps/_DeepForest/map/frozen_forest.dmm
+++ b/maps/_DeepForest/map/frozen_forest.dmm
@@ -648,6 +648,10 @@
 /obj/structure/table/onestar,
 /turf/simulated/floor/tiled/derelict/white_red_edges,
 /area/liberty/dungeon/outside/frozen_forest_simil_base)
+"pU" = (
+/obj/random/flora/wild,
+/turf/simulated/floor/snow,
+/area/liberty/dungeon/outside/frozen_forest)
 "qa" = (
 /turf/simulated/floor/wood/wild4,
 /area/liberty/dungeon/outside/frozen_forest_house)
@@ -831,6 +835,10 @@
 "tB" = (
 /turf/simulated/floor/rock/manmade/road,
 /area/liberty/dungeon/outside/frozen_forest_simil_base)
+"tE" = (
+/obj/random/flora/wild/high,
+/turf/simulated/floor/snow,
+/area/liberty/dungeon/outside/frozen_forest)
 "tG" = (
 /obj/machinery/light/floor,
 /obj/random/mob/roomba/any,
@@ -1280,6 +1288,10 @@
 /obj/item/stack/rods/random,
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/liberty/dungeon/outside/frozen_forest_simil_base)
+"Dk" = (
+/obj/random/flora/wild/med,
+/turf/simulated/floor/snow,
+/area/liberty/dungeon/outside/frozen_forest)
 "DD" = (
 /obj/random/gun_fancy/low_chance,
 /turf/simulated/floor/rock/dark,
@@ -1651,6 +1663,10 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/liberty/dungeon/outside/frozen_forest_simil_base)
+"LY" = (
+/obj/random/flora/wild/low,
+/turf/simulated/floor/snow,
+/area/liberty/dungeon/outside/frozen_forest)
 "Mg" = (
 /obj/random/rations/crayon,
 /turf/simulated/floor/rock/dark,
@@ -5947,7 +5963,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 Qt
 rf
@@ -7714,7 +7730,7 @@ rf
 rf
 Fy
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -8976,7 +8992,7 @@ rf
 JA
 rf
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -11224,7 +11240,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -13054,7 +13070,7 @@ rf
 rf
 sx
 rf
-rf
+Dk
 rf
 rf
 Qt
@@ -13235,7 +13251,7 @@ rf
 rf
 eN
 rf
-rf
+LY
 rf
 rf
 rf
@@ -13470,7 +13486,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 cZ
 rf
@@ -13506,7 +13522,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -13811,7 +13827,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -14057,7 +14073,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 rf
 Fy
@@ -14219,7 +14235,7 @@ vy
 vy
 rf
 rf
-rf
+tE
 rf
 rf
 rf
@@ -14283,7 +14299,7 @@ FW
 rf
 rf
 rf
-rf
+LY
 rf
 FW
 rf
@@ -14474,7 +14490,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -14565,7 +14581,7 @@ rf
 Iq
 rf
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -14583,7 +14599,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -14730,7 +14746,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -15224,7 +15240,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -15482,7 +15498,7 @@ rf
 rf
 jY
 rf
-rf
+tE
 rf
 rf
 rf
@@ -15983,7 +15999,7 @@ Fy
 rf
 rf
 rf
-rf
+Dk
 rf
 sx
 rf
@@ -16240,7 +16256,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -16324,7 +16340,7 @@ rf
 rf
 Fy
 rf
-rf
+tE
 rf
 rf
 rf
@@ -16752,7 +16768,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 sx
 rf
@@ -16793,7 +16809,7 @@ Bk
 rf
 rf
 rf
-rf
+LY
 rf
 Iq
 rf
@@ -17233,7 +17249,7 @@ rf
 jY
 rf
 rf
-rf
+Dk
 rf
 fa
 rf
@@ -17272,7 +17288,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -17401,7 +17417,7 @@ rf
 Iq
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -17539,7 +17555,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -18130,7 +18146,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -18818,7 +18834,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 jY
@@ -19105,6 +19121,7 @@ rf
 rf
 rf
 rf
+tE
 rf
 rf
 rf
@@ -19116,8 +19133,7 @@ rf
 rf
 rf
 rf
-rf
-rf
+pU
 rf
 Iq
 rf
@@ -19280,7 +19296,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -20664,7 +20680,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 si
 rf
@@ -20755,7 +20771,7 @@ rf
 rf
 Fy
 rf
-rf
+Dk
 rf
 FW
 rf
@@ -21070,7 +21086,7 @@ Bk
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -21113,7 +21129,7 @@ rf
 rf
 rf
 rf
-rf
+tE
 rf
 si
 rf
@@ -21838,7 +21854,7 @@ Fy
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -22586,7 +22602,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 FW
 rf
@@ -23866,7 +23882,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -23879,7 +23895,7 @@ rf
 jY
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -24045,7 +24061,7 @@ rf
 rf
 jY
 rf
-rf
+Dk
 rf
 EZ
 rf
@@ -24110,7 +24126,7 @@ rf
 rf
 rf
 UK
-rf
+LY
 rf
 rf
 rf
@@ -24546,7 +24562,7 @@ rf
 jY
 rf
 rf
-rf
+tE
 rf
 CD
 rf
@@ -25049,11 +25065,11 @@ rf
 rf
 rf
 rf
+tE
 rf
 rf
 rf
-rf
-rf
+tE
 Iq
 rf
 rf
@@ -25135,7 +25151,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 FW
 rf
@@ -25148,7 +25164,7 @@ rf
 si
 rf
 rf
-rf
+tE
 rf
 rf
 rf
@@ -25598,7 +25614,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -25935,7 +25951,7 @@ rf
 rf
 Qt
 rf
-rf
+LY
 rf
 rf
 Fy
@@ -26366,7 +26382,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -26622,7 +26638,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -26676,14 +26692,14 @@ rf
 rf
 Fy
 rf
-rf
+LY
 rf
 Fy
 rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -26951,7 +26967,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -27381,7 +27397,7 @@ rf
 Fy
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -27677,7 +27693,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 UK
@@ -27718,7 +27734,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -28171,7 +28187,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 Fy
 rf
@@ -28648,7 +28664,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -28858,7 +28874,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 jY
@@ -29663,7 +29679,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 UK
@@ -31404,7 +31420,7 @@ sx
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -31419,7 +31435,7 @@ rf
 rf
 rf
 rf
-rf
+pU
 rf
 rf
 rf
@@ -31940,7 +31956,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 Mj
@@ -34770,7 +34786,7 @@ Mj
 Mj
 UK
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -35531,7 +35547,7 @@ KA
 rf
 Nj
 rf
-rf
+LY
 rf
 rf
 rf
@@ -35958,7 +35974,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -35970,7 +35986,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -36031,7 +36047,7 @@ Mj
 Mj
 Mj
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -36285,7 +36301,7 @@ Mj
 rf
 rf
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -37041,7 +37057,7 @@ Mj
 rf
 rf
 rf
-rf
+tE
 rf
 rf
 rf
@@ -37543,7 +37559,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -37685,7 +37701,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -38043,7 +38059,7 @@ Mj
 Mj
 Mj
 rf
-rf
+Dk
 rf
 rf
 rf
@@ -39223,7 +39239,7 @@ XT
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -39750,7 +39766,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -41580,7 +41596,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -43028,7 +43044,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -43207,7 +43223,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 zu
 rf
@@ -44739,7 +44755,7 @@ rf
 rf
 rf
 rf
-rf
+pU
 rf
 rf
 rf
@@ -45203,7 +45219,7 @@ rf
 zu
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -46063,7 +46079,7 @@ rf
 rf
 ep
 rf
-rf
+LY
 rf
 rf
 rf
@@ -46258,7 +46274,7 @@ rf
 rf
 rf
 rf
-rf
+tE
 rf
 rf
 rf
@@ -46791,7 +46807,7 @@ XT
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -47999,7 +48015,7 @@ jY
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -49764,7 +49780,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 cG
 XT
@@ -51004,7 +51020,7 @@ rf
 rf
 Xq
 rf
-rf
+LY
 rf
 rf
 rf
@@ -51505,7 +51521,7 @@ rf
 jY
 rf
 rf
-rf
+LY
 rf
 FW
 rf
@@ -52268,7 +52284,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -52526,7 +52542,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -52765,7 +52781,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -53527,7 +53543,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -53588,7 +53604,7 @@ PY
 rf
 rf
 rf
-rf
+LY
 rf
 FW
 HG
@@ -53889,7 +53905,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -54065,7 +54081,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -54531,7 +54547,7 @@ rf
 rf
 si
 rf
-rf
+LY
 lq
 rf
 rf
@@ -54543,7 +54559,7 @@ si
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -55291,7 +55307,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -55889,7 +55905,7 @@ XQ
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -56305,7 +56321,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -56804,7 +56820,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -60911,7 +60927,7 @@ OO
 rf
 rf
 rf
-rf
+Dk
 rf
 XQ
 rf
@@ -61195,7 +61211,7 @@ rf
 rf
 rf
 rf
-rf
+LY
 rf
 rf
 rf
@@ -61417,7 +61433,7 @@ rf
 rf
 rf
 rf
-rf
+Dk
 rf
 rf
 rf

--- a/maps/__Liberty/map/_Liberty_Colony.dmm
+++ b/maps/__Liberty/map/_Liberty_Colony.dmm
@@ -4279,6 +4279,10 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/absolutism/storage)
+"biz" = (
+/obj/random/flora/wild/low,
+/turf/simulated/floor/snow,
+/area/liberty/outside/forest)
 "biN" = (
 /obj/structure/grille,
 /obj/effect/decal/cleanable/dirt,
@@ -8855,6 +8859,10 @@
 /obj/random/cluster/termite_no_despawn/lower_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1north)
+"csQ" = (
+/obj/random/flora/wild/high,
+/turf/simulated/floor/snow,
+/area/liberty/outside/inside_colony)
 "ctb" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/ammo_magazine/ammobox/shotgun/practiceshells,
@@ -30587,6 +30595,10 @@
 	},
 /turf/simulated/floor/tiled/dark/bluecorner,
 /area/liberty/command/tcommsat/computer)
+"iwN" = (
+/obj/random/flora/wild/med,
+/turf/simulated/floor/snow,
+/area/liberty/outside/forest)
 "iwZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -42283,8 +42295,8 @@
 /area/liberty/crew_quarters/dorm4)
 "lOH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/landmark/join/start/trapper,
 /obj/item/stool,
+/obj/landmark/join/start/shipbreaker,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/pros/prep)
 "lOS" = (
@@ -51458,8 +51470,8 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/liberty/crew_quarters/fitness)
 "oxv" = (
-/obj/landmark/join/start/shipbreaker,
 /obj/item/stool,
+/obj/landmark/join/start/trapper,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/pros/prep)
 "oxC" = (
@@ -59442,6 +59454,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/liberty/medical/sleeper)
+"qGu" = (
+/obj/random/flora/wild/low,
+/turf/simulated/floor/snow,
+/area/liberty/outside/inside_colony)
 "qGw" = (
 /obj/structure/flora/small/grassb3,
 /turf/simulated/floor/asteroid/grass,
@@ -60008,6 +60024,10 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/liberty/storage/primary)
+"qNK" = (
+/obj/random/flora/wild/high,
+/turf/simulated/floor/snow,
+/area/liberty/outside/forest)
 "qNL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -66286,7 +66306,6 @@
 /obj/structure/table/steel,
 /obj/random/lathe_disk,
 /obj/random/lathe_disk,
-/obj/structure/window/reinforced,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -171183,7 +171202,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+biz
 wgB
 wgB
 wgB
@@ -176254,7 +176273,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+iwN
 wgB
 kfM
 kfM
@@ -176654,7 +176673,7 @@ kfM
 kfM
 wgB
 wgB
-wgB
+iwN
 wgB
 wgB
 wgB
@@ -178069,7 +178088,7 @@ cqw
 wgB
 wgB
 wgB
-wgB
+iwN
 wgB
 wgB
 wgB
@@ -178879,7 +178898,7 @@ wgB
 wgB
 rtf
 wgB
-wgB
+iwN
 wgB
 wgB
 kfM
@@ -181081,7 +181100,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+biz
 wgB
 wgB
 wgB
@@ -181493,7 +181512,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+biz
 wgB
 wgB
 wgB
@@ -183508,7 +183527,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+biz
 wgB
 wgB
 wgB
@@ -183908,7 +183927,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+biz
 wgB
 wgB
 wgB
@@ -186887,7 +186906,7 @@ ddD
 xMC
 rQC
 rQC
-rQC
+csQ
 rQC
 rQC
 rQC
@@ -189117,7 +189136,7 @@ rQC
 rQC
 rQC
 rQC
-rQC
+csQ
 rQC
 rQC
 rQC
@@ -189585,7 +189604,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+biz
 wgB
 wgB
 wgB
@@ -189964,7 +189983,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+biz
 wgB
 wgB
 wgB
@@ -192529,7 +192548,7 @@ ddD
 qwd
 rQC
 rQC
-rQC
+qGu
 rQC
 rQC
 rQC
@@ -193356,7 +193375,7 @@ hKS
 rQC
 rQC
 rQC
-rQC
+csQ
 rQC
 rQC
 rQC
@@ -195641,7 +195660,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+biz
 wgB
 wgB
 wgB
@@ -199042,7 +199061,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+biz
 wgB
 wgB
 wgB
@@ -204525,7 +204544,7 @@ rtf
 wgB
 wgB
 wgB
-wgB
+qNK
 wgB
 iue
 odh
@@ -204721,7 +204740,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+qNK
 wgB
 wgB
 wgB
@@ -205330,7 +205349,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+qNK
 wgB
 wgB
 wgB
@@ -205931,7 +205950,7 @@ wgB
 wgB
 wgB
 wgB
-wgB
+qNK
 wgB
 wgB
 wgB


### PR DESCRIPTION
Adds medicinal flora spawners around the maps. Amount will be adjusted as feedback shows during play.

Adjusts snow trees' pixel_x and pixel_y offsets to match their sprites better and have a more sensible collision tile.

Removes a window in Fontaine that blocked access to a corner, fixes #119.

Moves Trapper and Shipbreaker spawn locations to their correct sides.