### PR TITLE
small ports

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -42,6 +42,7 @@
 		H.flash(3, FALSE , TRUE , TRUE, 15)
 	else
 		M.flash(5, FALSE, TRUE , TRUE)
+	M.stats.addTempStat(STAT_ROB, -STAT_LEVEL_ADEPT, 10 SECONDS, "flashbang")
 	M.stats.addTempStat(STAT_VIG, -STAT_LEVEL_ADEPT, 10 SECONDS, "flashbang")
 	M.stats.addTempStat(STAT_COG, -STAT_LEVEL_ADEPT, 10 SECONDS, "flashbang")
 	M.stats.addTempStat(STAT_BIO, -STAT_LEVEL_ADEPT, 10 SECONDS, "flashbang")
@@ -133,12 +134,14 @@
 		var/obj/item/organ/internal/eyes/E = H.random_organ_by_process(OP_EYES)
 		if (E && E.damage >= E.min_bruised_damage)
 			to_chat(M, SPAN_DANGER("Your eyes start to burn badly!"))
+		H.add_recoil(300 - ear_safety * 100)
 	if (M.ear_damage >= 15)
 		to_chat(M, SPAN_DANGER("Your ears start to ring badly!"))
 	else
 		if (M.ear_damage >= 5)
 			to_chat(M, SPAN_DANGER("Your ears start to ring!"))
 	if(stat_reduction)
+		M.stats.addTempStat(STAT_ROB, stat_def, 10 SECONDS, "flashbang")
 		M.stats.addTempStat(STAT_VIG, stat_def, 10 SECONDS, "flashbang")
 		M.stats.addTempStat(STAT_COG, stat_def, 10 SECONDS, "flashbang")
 		M.stats.addTempStat(STAT_BIO, stat_def, 10 SECONDS, "flashbang")

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -223,13 +223,19 @@
 		/obj/item/clipboard,
 		/obj/item/paper,
 		/obj/item/paper_bundle,
+		/obj/item/paper_bin,
 		/obj/item/card/id,
 		/obj/item/book,
 		/obj/item/newspaper,
+		/obj/item/pen,
+		/obj/item/stamp,
+		/obj/item/packageWrap,
+		/obj/item/device/destTagger,
+		/obj/item/smallDelivery,
 		/obj/item/photo,
 		/obj/item/spacecash,
 		/obj/item/coin,
-		/obj/item/device/toner
+		/obj/item/device/toner,
 		)
 
 /obj/item/gripper/research //A general usage gripper, used for toxins/robotics/xenobio/etc
@@ -310,6 +316,8 @@
 		/obj/item/am_containment,
 		/obj/item/am_shielding_container,
 		/obj/item/clothing/mask/smokable/cigarette,
+		/obj/item/spacecash,
+		/obj/item/device/eftpos,
 		///obj/item/reagent_containers/cooking_container //PArt of cooking overhaul, not yet ported
 		)
 


### PR DESCRIPTION
These looked easy so. Ports Eris PRs #8115, #8103 and #8125

Flashbangs now also apply a Robustness penalty.
Flashbangs now apply recoil based on your ear protection level.

Service and Paperwork grippers can grip more things, most notably Cash and EFTPOS devices for the former.
