### PR TITLE
Sugar Honey Glucose

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -43,10 +43,6 @@
 //Genetics Perks
 #define PERK_SPLICER /datum/perk/background/splicer
 
-// Food perks
-#define PERK_CARNIVORE /datum/perk/background/carnivore
-#define PERK_HERBIVORE /datum/perk/background/herbivore
-
 /////////////
 //Job Perks//
 /////////////

--- a/code/datums/setup_option/backgrounds/habit/habit.dm
+++ b/code/datums/setup_option/backgrounds/habit/habit.dm
@@ -1,21 +1,3 @@
-/datum/category_item/setup_option/background/habit/herbivore
-	name = "Grass Devourer"
-	desc = "When your teacher said 'Eat your greens' you took it quite literally and only ate those from then onwards. \
-	Or perhaps you just didn't ever have access to proper meat or just maybe your choresterol got too high. \
-	Whichever the case, you are now after minor gene therapy more accustomed to vegetables and fruit leaving meat as undesirable for your body."
-
-	restricted_to_species = list(FORM_HUMAN, FORM_KRIOSAN, FORM_SABLEKYNE, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_OPIFEX, FORM_CHTMANT, FORM_CINDAR)
-	perks = list(PERK_HERBIVORE)
-
-/datum/category_item/setup_option/background/habit/carnivore
-	name = "Red Meat Enjoyer"
-	desc = "Steak, meatball, kebab, sausage, name it and you want it, the taste of meat is insepperable from your pallete.\
-	Like your ancestors you are running on pure diet of red meat, two cans of coffee and cold mug of beer.\
-	After a minor gene therapy to make this possibility however your body completely rejects any idea of processing plant-based foods."
-
-	restricted_to_species = list(FORM_HUMAN, FORM_KRIOSAN, FORM_SABLEKYNE, FORM_AKULA, FORM_MARQUA, FORM_NARAMAD, FORM_OPIFEX, FORM_CHTMANT, FORM_CINDAR)
-	perks = list(PERK_CARNIVORE)
-
 /datum/category_item/setup_option/background/habit/chainsmoker
 	name = "Terminal Smoker"
 	desc = "Nicotine is way of life, nicotine is love, nicotine is your lifeline, without it you wouldn't be whole.\

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -107,7 +107,7 @@
 	permitted_wings = list()
 
 	darksight = 3 //Cat eyes
-	perks = list(PERK_LASTSTAND, PERK_BONE, PERK_BRAWN, PERK_CARNIVORE)
+	perks = list(PERK_LASTSTAND, PERK_BONE, PERK_BRAWN)
 
 /datum/species/sablekyne/get_bodytype()
 	return "Sablekyne"
@@ -275,7 +275,7 @@
 	permitted_tail  = list("Akula Tail")
 	permitted_wings = list()
 
-	perks = list(PERK_RECKLESSFRENZY, PERK_IRON_FLESH, PERK_CARNIVORE)
+	perks = list(PERK_RECKLESSFRENZY, PERK_IRON_FLESH)
 
 /datum/species/akula/get_bodytype()
 	return "Akula"

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -471,6 +471,7 @@
 	description = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."
 	taste_description = "sugar"
 	taste_mult = 1.8
+	overdose = 50
 	reagent_state = SOLID
 	color = "#FFFFFF"
 	glass_icon_state = "iceglass"
@@ -479,7 +480,11 @@
 	common = TRUE //everyone knows what sugar is
 
 /datum/reagent/organic/sugar/affect_blood(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	M.adjustNutrition(4 * effect_multiplier)
+	M.adjustNutrition(0.5 * effect_multiplier)
+
+/datum/reagent/organic/sugar/overdose(mob/living/carbon/human/user, alien)
+	var/obj/item/organ/internal/blood_vessel/user_vessel = user.random_organ_by_process(OP_BLOOD_VESSEL)
+	create_overdose_wound(user_vessel, user, /datum/component/internal_wound/organic/heavy_poisoning, "accumulation")
 
 /datum/reagent/sulfur
 	name = "Sulfur"

--- a/code/modules/reagents/reagents/food-Drinks.dm
+++ b/code/modules/reagents/reagents/food-Drinks.dm
@@ -43,13 +43,6 @@
 	affect_ingest(M, alien, effect_multiplier * 1.2)
 
 /datum/reagent/organic/nutriment/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	if(ishuman(M))
-		if(M.stats.getPerk(PERK_HERBIVORE))
-			nutriment_factor = 7
-		if(M.stats.getPerk(PERK_CARNIVORE))
-			nutriment_factor = 1
-
-	// Small bodymass, more effect from lower volume.
 	M.adjustNutrition(nutriment_factor * (issmall(M) ? effect_multiplier * 2 : effect_multiplier)) // For hunger and fatness
 	M.add_chemical_effect(CE_BLOODRESTORE, 0.1 * (issmall(M) ? effect_multiplier * 2 : effect_multiplier))
 
@@ -60,8 +53,13 @@
 	taste_description = "sweetness"
 	color = "#FFFFFF"
 	scannable = TRUE
+	overdose = 50
 	injectable = 1
 	common = TRUE //It's basically sugar
+
+/datum/reagent/organic/nutriment/glucose/overdose(mob/living/carbon/human/user, alien)
+	var/obj/item/organ/internal/blood_vessel/user_vessel = user.random_organ_by_process(OP_BLOOD_VESSEL)
+	create_overdose_wound(user_vessel, user, /datum/component/internal_wound/organic/heavy_poisoning, "accumulation")
 
 /datum/reagent/organic/nutriment/protein
 	name = "Protein"
@@ -72,13 +70,6 @@
 	common = TRUE //Protein Shake
 
 /datum/reagent/organic/nutriment/protein/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
-	if(ishuman(M))
-		if(M.stats.getPerk(PERK_CARNIVORE))
-			nutriment_factor = 7
-		if(M.stats.getPerk(PERK_HERBIVORE))
-			nutriment_factor = 1
-
-	// Small bodymass, more effect from lower volume.
 	M.adjustNutrition(nutriment_factor * (issmall(M) ? effect_multiplier * 2 : effect_multiplier)) // For hunger and fatness
 	M.add_chemical_effect(CE_BLOODRESTORE, 0.1 * (issmall(M) ? effect_multiplier * 2 : effect_multiplier))
 
@@ -89,13 +80,13 @@
 	description = "A slurry of bland chemical preservatives that takes years, if not decades, to go bad."
 	color = "#440000"
 	common = TRUE //Snacks
-	nutriment_factor = 1
+	nutriment_factor = -1
 	regen_factor = 0.2
 
 /datum/reagent/organic/nutriment/preservatives/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	if(ishuman(M))
 		if(M.stats.getPerk(PERK_SNACKIVORE))
-			M.adjustNutrition(nutriment_factor * 10)
+			M.adjustNutrition(nutriment_factor * -10)
 			M.adjustOxyLoss(-0.3 * effect_multiplier)
 			M.heal_organ_damage(0.1 * effect_multiplier, 0.1 * effect_multiplier)
 			M.add_chemical_effect(CE_TOXIN, 1)
@@ -116,13 +107,18 @@
 	id = "honey"
 	description = "A golden yellow syrup, loaded with sugary sweetness."
 	taste_description = "sweetness"
-	nutriment_factor = 4
+	nutriment_factor = 1
+	overdose = 30
 	color = "#FFFF00"
 	common = TRUE
 
 /datum/reagent/organic/nutriment/honey/affect_ingest(var/mob/living/carbon/M, var/alien, var/effect_multiplier)
 	..()
 	M.add_chemical_effect(CE_ANTITOX, 0.5)
+
+/datum/reagent/organic/nutriment/honey/overdose(mob/living/carbon/human/user, alien)
+	var/obj/item/organ/internal/blood_vessel/user_vessel = user.random_organ_by_process(OP_BLOOD_VESSEL)
+	create_overdose_wound(user_vessel, user, /datum/component/internal_wound/organic/heavy_poisoning, "accumulation")
 
 /datum/reagent/organic/nutriment/flour
 	name = "flour"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Removes Herbi/Carnivore perks as they are extremely buggy in their implementation
Gave Honey Glucose and Sugar overdose effects and limits while reducing their effectivness to bypass actually eating food
	
<hr>
</details>

## Changelog
:cl:
del: Herbi/Carnivore
balance: Honey Sugar Glucose bypassing need to eat entirely
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
