### PR TITLE
custodian strings and materials

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -38,7 +38,7 @@
 	build_path = /obj/item/stack/material/cardboard/random // I guess it depends on the protein content.
 */
 /datum/design/bioprinter/leather/holster/saber/greatsword/churchprint
-	name = "Absolutist Sword Scabbard"
+	name = "Custodian Scabbard"
 	build_path = /obj/item/clothing/accessory/holster/saber/greatsword/churchprint
 	materials = list(MATERIAL_BIO_SILK = 0.1, MATERIAL_CARBON_FIBER = 0.2)
 
@@ -111,7 +111,7 @@
 /datum/design/bioprinter/nt_clothes/armor_kit
 	name = "Armor Bundle"
 	build_path = /obj/item/gunbox/church
-	materials = list(MATERIAL_BIO_SILK = 15, MATERIAL_CARBON_FIBER = 15, MATERIAL_BIOMATTER = 20)
+	materials = list(MATERIAL_BIO_SILK = 15, MATERIAL_CARBON_FIBER = 15)
 
 /datum/design/bioprinter/nt_clothes/acolyte_armor
 	name = "Vector Armor"
@@ -182,42 +182,42 @@
 
 //[MELEE]
 /datum/design/autolathe/sword/nt_sword
-	name = "NT Short Sword"
+	name = "Ulfberth"
 	build_path = /obj/item/tool/sword/nt/shortsword
 	materials = list(MATERIAL_BIO_SILK = 1, MATERIAL_CARBON_FIBER = 8)
 
 /datum/design/autolathe/sword/nt_longsword
-	name = "NT Longsword"
+	name = "Horseman Axe"
 	build_path = /obj/item/tool/sword/nt/longsword
 	materials = list(MATERIAL_BIO_SILK = 1, MATERIAL_CARBON_FIBER = 12)
 
 /datum/design/autolathe/sword/nt_dagger
-	name = "NT Dagger"
+	name = "Custodian Seax"
 	build_path = /obj/item/tool/knife/dagger/nt
 	materials = list(MATERIAL_BIO_SILK = 1, MATERIAL_CARBON_FIBER = 3)
 
 /datum/design/autolathe/sword/nt_halberd
-	name = "NT Halberd"
+	name = "Custodian Atgeir"
 	build_path = /obj/item/tool/spear/halberd
 	materials = list(MATERIAL_BIO_SILK = 1, MATERIAL_CARBON_FIBER = 18)
 
 /datum/design/autolathe/sword/nt_spear
-	name = "NT Spear"
+	name = "Custodian Francisca"
 	build_path = /obj/item/tool/sword/nt/spear
 	materials = list(MATERIAL_BIO_SILK = 1, MATERIAL_CARBON_FIBER = 4)
 
 /datum/design/autolathe/sword/nt_scourge
-	name = "NT Scourge"
+	name = "Custodian Nagaika"
 	build_path = /obj/item/tool/sword/nt/scourge
 	materials = list(MATERIAL_BIO_SILK = 10, MATERIAL_CARBON_FIBER = 18)
 
 /datum/design/autolathe/shield/nt_shield
-	name = "NT Shield"
+	name = "Custodian Scutum Shield"
 	build_path = /obj/item/shield/riot/nt
 	materials = list(MATERIAL_BIO_SILK = 3, MATERIAL_CARBON_FIBER = 21)
 
 /datum/design/autolathe/nt/shield/nt_buckler
-	name = "NT Buckler"
+	name = "Custodian Targe Shield"
 	build_path = /obj/item/shield/buckler/nt
 	materials = list(MATERIAL_BIO_SILK = 2, MATERIAL_CARBON_FIBER = 12)
 
@@ -237,7 +237,7 @@
 	materials = list(MATERIAL_BIO_SILK = 1, MATERIAL_CARBON_FIBER = 12)
 
 /datum/design/autolathe/sword/nt_flanged
-	name = "NT Flanged Mace"
+	name = "Emberblaze Warhammer"
 	build_path = /obj/item/tool/sword/nt/flanged
 	materials = list(MATERIAL_BIO_SILK = 1, MATERIAL_CARBON_FIBER = 16)
 

--- a/code/game/gamemodes/scores.dm
+++ b/code/game/gamemodes/scores.dm
@@ -308,14 +308,14 @@ GLOBAL_VAR_INIT(score_technomancer_faction_item_loss, 0)
 
 	//Church
 	dat += {"
-	<u>Church of Bonfire scores</u><br>
+	<u>Custodians of Bonfire scores</u><br>
 	<b>Base score:</b> [green_text(GLOB.initial_neotheology_score)]<br>
 	<b>Lost faction items:</b> [GLOB.neotheology_faction_item_loss] ([to_score_color(GLOB.score_neotheology_faction_item_loss)] Points)<br>
 	<b>Faction objectives completed:</b> [GLOB.neotheology_objectives_completed] ([to_score_color(GLOB.neotheology_objectives_score)] Points)<br>
 	<b>Biomatter produced:</b> [GLOB.biomatter_neothecnology_amt] ([to_score_color(GLOB.biomatter_score)] Points)<br>
 	<b>Total of conversions:</b> [GLOB.new_neothecnology_convert] ([to_score_color(GLOB.new_neothecnology_convert_score)] Points)<br>
 	<b>Group rituals performed:</b> [GLOB.grup_ritual_performed] ([to_score_color(GLOB.grup_ritual_score)] Points)<br>
-	<b>Final Church of Bonfire score:</b> [get_color_score(GLOB.neotheology_score, GLOB.neotheology_score)] Points<br><br>
+	<b>Final Custodians of Bonfire score:</b> [get_color_score(GLOB.neotheology_score, GLOB.neotheology_score)] Points<br><br>
 	"}
 
 	//Skylight

--- a/code/game/machinery/vendor/weapon_vendors.dm
+++ b/code/game/machinery/vendor/weapon_vendors.dm
@@ -184,8 +184,8 @@
 	auto_price = FALSE
 
 /obj/machinery/vending/theomat
-	name = "Church of Bonfire Theo-Mat"
-	desc = "A church dispensary for disciples and new converts."
+	name = "Custodian Vendo-Mat"
+	desc = "A Custodian dispensary for both new and established members."
 	product_slogans = "Find peace through faith.;Help humanity ascend, join your brethren today!;Come and seek a new life!;Safety in brotherhood!"
 	product_ads = "Praise!;Pray!;Only for the faithful!;Ascend!;Seek a new life!;Better living through technology!"
 	icon_state = "teomat"
@@ -221,7 +221,7 @@
 					/obj/item/grenade/chem_grenade/antiweed/nt_antiweed = 5,
 					/obj/item/grenade/chem_grenade/cleaner/nt_cleaner = 5,
 					/obj/item/tool/knife/dagger/nt = 3,
-					/obj/item/tool/sword/nt = 3,
+					/obj/item/tool/sword/nt/shortsword = 3,
 					/obj/item/gun/energy/ntpistol = 3,
 					/obj/item/computer_hardware/hard_drive/portable/design/nt_new_guns = 2,
 					/obj/item/computer_hardware/hard_drive/portable/design/nt_basic_arms/public = 2,
@@ -261,7 +261,7 @@
 					/obj/item/grenade/chem_grenade/antiweed/nt_antiweed = 25,
 					/obj/item/grenade/chem_grenade/cleaner/nt_cleaner = 50,
 					/obj/item/tool/knife/dagger/nt = 50,
-					/obj/item/tool/sword/nt = 100,
+					/obj/item/tool/sword/nt/shortsword = 100,
 					/obj/item/gun/energy/ntpistol = 120,
 					/obj/item/computer_hardware/hard_drive/portable/design/nt_new_guns = 800,
 					/obj/item/computer_hardware/hard_drive/portable/design/nt_basic_arms/public = 100,

--- a/code/game/objects/items/oddities_faction.dm
+++ b/code/game/objects/items/oddities_faction.dm
@@ -49,7 +49,7 @@
 
 /obj/item/device/von_krabin
 	name = "Von-Krabin Stimulator"
-	desc = "A strange anomalous item given to the research directors of Phokorus Institute as its latent effects enhance the mind. Some say this is an unfinished prototype of the technology the church of absolute uses to enhance the abilities of others."
+	desc = "A strange anomalous item given to the research directors of Phokorus Institute as its latent effects enhance the mind."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "von-krabin"
 	item_state = "von-krabin"

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -733,8 +733,8 @@
 	toysay = "\"Vodka!\""
 
 /obj/item/toy/figure/character/bobblehead/acolyte
-	name = "acolyte figurine"
-	desc = "Church of Bonfire \"New Faith Life\" brand figurine of a vector, hooded both physically and spiritually from that which would lead them astray."
+	name = "custodian figurine"
+	desc = "Custodians of Bonfire \"New Life\" brand figurine of an oathbound, protected both physically and mentally from that which would lead them astray."
 	icon_state = "acolyte"
 	toysay = "\"Brotherhood.\""
 

--- a/code/game/objects/items/weapons/autolathe_disk/bonfire_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/bonfire_disks.dm
@@ -62,8 +62,8 @@
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/nt/bioprinter
-	disk_name = "Church of Bonfire Utilities Plus"
-	desc = "This disk is sole property of the church, the files within are encrypted and should not be used, taken, or tested by anyone not affiliated with the Bonfire."
+	disk_name = "Custodians of Bonfire Utilities Plus"
+	desc = "This disk is sole property of the custodians, the files within are encrypted and should not be used, taken, or tested by anyone not affiliated with the Custodians."
 	icon_state = "neotheology_testament_u"
 	license = -1
 	designs = list(
@@ -82,7 +82,7 @@
 	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/nt/bioprinter/public
-	disk_name = "Church of Bonfire Bioprinter Products and Utilities Basic"
+	disk_name = "Custodians of Bonfire Products and Utilities Basic"
 	desc = "A limited design disk for cleaning, gardening and some production of meats and milk."
 	license = 20
 

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -1,8 +1,7 @@
 //Warning! If you change icon_state or item_state, make sure you change path for sneath as well. icons/obj/sneath.dmi
 /obj/item/tool/sword/nt // not supposed to be in the game, had to make the shortsword its own type to prevent fucking up the scourge. sorry.
-	name = "short sword"
-	desc = "A saintly looking sword, made to do God's work. \
-	It bears a tau cross marking it as produced by the Church of Bonfire's New Testament weapons division."
+	name = "base item"
+	desc = "If you can see this in-game, report it."
 	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_shortsword"
 	item_state = "nt_shortsword"
@@ -10,7 +9,7 @@
 	throwforce = WEAPON_FORCE_WEAK
 	armor_penetration = ARMOR_PEN_DEEP
 	price_tag = 300
-	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_STEEL = 5)
+	matter = list(MATERIAL_BIO_SILK = 25, MATERIAL_STEEL = 5)
 
 /obj/item/tool/sword/nt/equipped(mob/living/M)
 	. = ..()
@@ -20,9 +19,9 @@
 		embed_mult = initial(embed_mult)
 
 /obj/item/tool/sword/nt/shortsword
-	name = "short sword"
-	desc = "A saintly looking sword, made to do God's work. \
-	It bears a tau cross marking it as produced by the Church of Bonfire's New Testament weapons division."
+	name = "ulfberth"
+	desc = "As much as the swords may be underused by the Custodians in exchange for polearms and axes, many short swords are produced with a cheap price. \
+	The ulfberth are regarded as a work of art rather than a weapon - yet more effective than a machete nonetheless."
 	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_shortsword"
 	item_state = "nt_shortsword"
@@ -30,37 +29,35 @@
 	throwforce = WEAPON_FORCE_WEAK
 	armor_penetration = ARMOR_PEN_DEEP
 	price_tag = 300
-	matter = list(MATERIAL_BIOMATTER = 25, MATERIAL_STEEL = 5)
+	matter = list(MATERIAL_BIO_SILK = 25, MATERIAL_STEEL = 5)
 
 /obj/item/tool/sword/nt/longsword
-	name = "longsword"
-	desc = "A saintly looking longsword, recommended by experienced crusaders. \
-	It bears a tau cross marking it as produced by the Church of Bonfire's New Testament weapons division."
+	name = "horseman axe"
+	desc = "An efficient tin-opener of a weapon, excellent for penetrating armor - the sight of such a large axe is not far-fetched from horror stories, as such blade and weight can easily chop an arm. \
+	This piece of equipment is the most well used piece of melee weaponry of the Custodians."
 	icon_state = "nt_longsword"
 	item_state = "nt_longsword"
 	force = WEAPON_FORCE_ROBUST
 	armor_penetration = ARMOR_PEN_EXTREME
 	w_class = ITEM_SIZE_BULKY
 	price_tag = 500
-	matter = list(MATERIAL_BIOMATTER = 75, MATERIAL_STEEL = 10, MATERIAL_PLASTEEL = 5)
+	matter = list(MATERIAL_BIO_SILK = 75, MATERIAL_STEEL = 10, MATERIAL_CARBON_FIBER = 5)
 
 /obj/item/tool/knife/dagger/nt
-	name = "dagger"
-	desc = "A saintly looking dagger, may the absolute have mercy. \
-	It bears a tau cross marking it as produced by the Church of Bonfire's New Testament weapons division."
+	name = "custodian seax"
+	desc = "A really small sword used to puncture enemies in between armor, or to be used as a tool for cutting like a knife, even if clearly more efficient for stabbing."
 	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_dagger"
 	item_state = "nt_dagger"
 	force = WEAPON_FORCE_PAINFUL
 	armor_penetration = ARMOR_PEN_MASSIVE
 	price_tag = 120
-	matter = list(MATERIAL_BIOMATTER = 10, MATERIAL_STEEL = 1)
+	matter = list(MATERIAL_BIO_SILK = 10, MATERIAL_STEEL = 1)
 
 /obj/item/tool/spear/halberd
-	name = "halberd"
-	desc = "This weapon of ancient design appears to be a spear-axe hybrid. \
-	It saw a lot of use back in the Dark Ages back on Earth - in more recent times, sablekyne hunters use a similar weapon \
-	on their homeworlds, the weapons practical use taking down huge and heavily armored wildlife lead to the church adopting its own design."
+	name = "custodian atgeir"
+	desc = "The polearm that anticipates bloodshed, serving in the battlefield as a multipurpose staff with a spearhead mixed with the blade of an axe. \
+	The weapon is large and heavy, very difficult to store - yet way more brutal than any average melee weapon."
 	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_halberd"
 	item_state = "nt_halberd"
@@ -68,12 +65,12 @@
 	force = WEAPON_FORCE_BRUTAL
 	armor_penetration = ARMOR_PEN_MASSIVE
 	price_tag = 600
-	matter = list(MATERIAL_BIOMATTER = 80, MATERIAL_STEEL = 8, MATERIAL_WOOD = 10, MATERIAL_PLASTEEL = 2)
+	matter = list(MATERIAL_BIO_SILK = 80, MATERIAL_STEEL = 8, MATERIAL_WOOD = 10, MATERIAL_CARBON_FIBER = 2)
 
 /obj/item/tool/sword/nt/scourge
-	name = "scourge"
-	desc = "A saintly looking scourge, extreme punishment in handheld form. Can be extended to hurt more. \
-	It bears a tau cross marking it as produced by the Church of Bonfire's New Testament weapons division."
+	name = "custodian nagaika"
+	desc = "A whip made from compacted and oil-hardened silk with dense dark silver on its tip, with protubing blades that open and close on impact to inflict superfluous injury, the very same reason why Hollow-points are considered a war crime to use. \
+	Good thing whoever wrote that only included “bullets”."
 	icon_state = "nt_scourge"
 	item_state = "nt_scourge"
 	force = WEAPON_FORCE_ROBUST
@@ -86,7 +83,7 @@
 	var/stun = 0
 	w_class = ITEM_SIZE_BULKY
 	price_tag = 800
-	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 2)
+	matter = list(MATERIAL_BIO_SILK = 50, MATERIAL_STEEL = 5, MATERIAL_CARBON_FIBER = 2)
 	has_alt_mode = FALSE
 
 /obj/item/tool/sword/nt/scourge/attack_self(mob/user)
@@ -129,9 +126,9 @@
 		O.say(pick("LORD", "MERCY", "SPARE", "ME", "HAVE", "PLEASE"))
 
 /obj/item/tool/sword/nt/spear
-	name = "spear"
-	desc = "A saint looking short spear, designed for use with a shield or as a throwing weapon. \
-	The spear-tip usually breaks after being thrown at a target, but it can be hammered into shape again."
+	name = "custodian francisca"
+	desc = "The Francisca is an efficient throwing axe with an arch-shaped head. Small and concealable, the angle of the blade allows better breaking of shields, disrupting enemy lines and wounding an enemy hand-to-hand combat would happen. \
+	Even if the blade were not to strike the target, its weight has the potential of breaking necks."
 	icon_state = "nt_spear"
 	item_state = "nt_spear"
 	wielded_icon = "nt_spear_wielded"
@@ -143,7 +140,7 @@
 	armor_penetration = ARMOR_PEN_HALF
 	throw_speed = 3
 	price_tag = 150
-	matter = list(MATERIAL_BIOMATTER = 20, MATERIAL_PLASTEEL = 10) // More expensive, high-end spear
+	matter = list(MATERIAL_BIO_SILK = 20, MATERIAL_CARBON_FIBER = 10) // More expensive, high-end spear
 
 /obj/item/tool/sword/nt/spear/equipped(mob/living/W)
 	. = ..()
@@ -173,16 +170,16 @@
 			tipbroken = FALSE
 
 /obj/item/tool/sword/nt/flanged
-	name = "flanged mace"
-	desc = "A saintly looking mace, designed to be a beacon of hope in the darkest of times. Devotees can activate it to light their path. \
-	It bears a tau cross marking it as produced by the Church of Bonfire's New Testament weapons division."
+	name = "emberblaze warhammer"
+	desc = "An one handed Raven's beak that rapidly blazes when in connection with the Hearthcore and transfers its massive heat towards an chosen victim way worse than an laser sword would, enough to cause third-degree burns, and it is used to counter enemies using armor with high melee protection. \
+	It is TOO efficient to cleanse the maintenance - to the point that it is more likely to dust giant insects rather than allowing the Custodian to gather its meat for materials."
 	icon_state = "nt_flanged"
 	item_state = "nt_flanged"
 	force = WEAPON_FORCE_ROBUST
 	armor_penetration = ARMOR_PEN_MASSIVE
 	w_class = ITEM_SIZE_BULKY
 	price_tag = 800
-	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 5, MATERIAL_SILVER = 3)
+	matter = list(MATERIAL_BIO_SILK = 50, MATERIAL_STEEL = 5, MATERIAL_CARBON_FIBER = 5, MATERIAL_SILVER = 3)
 	tool_qualities = list(QUALITY_HAMMERING = 10) //Not designed for that fine nailing
 	var/glowing = FALSE
 	sharp = FALSE
@@ -193,17 +190,17 @@
 	var/mob/living/carbon/human/theuser = user
 	var/obj/item/implant/core_implant/cruciform/CI = theuser.get_core_implant()
 	if(!CI || !CI.active || !CI.wearer || !istype(CI,/obj/item/implant/core_implant/cruciform))
-		to_chat(user, SPAN_WARNING("You do not have a cruciform with which to light this beacon!"))
+		to_chat(user, SPAN_WARNING("You do not have a Hearthcore with which to light this beacon!"))
 		return
 	if(CI.power < 20)
 		to_chat(user, SPAN_WARNING("You do not have enough power to light up the beacon!"))
 		return
 	if(glowing)
-		to_chat(user, SPAN_WARNING("The flanged mace is still lit up."))
+		to_chat(user, SPAN_WARNING("The warhammer is still lit up."))
 		return
 	else
 		set_light(l_range = 4, l_power = 2, l_color = COLOR_YELLOW)
-		to_chat(user, SPAN_WARNING("The beacon has been lit!"))
+		to_chat(user, SPAN_WARNING("The warhammer has been lit!"))
 		glowing = TRUE
 		update_icon()
 		damtype = BURN
@@ -283,16 +280,16 @@
 	..()
 
 /obj/item/shield/riot/nt
-	name = "shield"
-	desc = "A saintly looking shield, let the God protect you. \
-	It bears a tau cross marking it as produced by the Church of Bonfire's New Testament weapons division. \
-	Has several leather straps on the back to hold melee weapons."
+	name = "custodian scutum shield"
+	desc = "A wall of a shield, oblong, convex and absurdly difficult to store, yet efficient to keep bullets and melee attacks at bay. \
+	The reinforcements of the shield allows major protection for an experienced user, yet its efficiency is limited for the inexperienced. \
+	It has leather straps behind it to store large equipment such as staves, throwing spears and others. This shield in specific constantly releases flames to light the way of it’s user."
 	icon = 'icons/obj/nt_melee.dmi'
 	icon_state = "nt_shield"
 	item_state = "nt_shield"
 	force = WEAPON_FORCE_DANGEROUS
 	armor_list = list(melee = 20, bullet = 20, energy = 10, bomb = 15, bio = 0, rad = 0)
-	matter = list(MATERIAL_BIOMATTER = 50, MATERIAL_STEEL = 10, MATERIAL_PLASTEEL = 10, MATERIAL_GOLD = 5)
+	matter = list(MATERIAL_BIO_SILK = 50, MATERIAL_STEEL = 10, MATERIAL_CARBON_FIBER = 10, MATERIAL_GOLD = 5)
 	price_tag = 1000
 	base_block_chance = 60
 	item_flags = DRAG_AND_DROP_UNEQUIP
@@ -357,12 +354,13 @@
 	return base_block_chance
 
 /obj/item/shield/buckler/nt
-	name = "NT Parma"
-	desc = "A round shield with a golden trim. Has several biomatter-leather straps on the back to hold melee weapons."
+	name = "custodian targe shield"
+	desc = "A small shield efficient for bashing enemies in the head as much as it allows the user to protect themselves from damage. \
+	Rather useless for the inexperienced, yet the ones who mastered the use of shields may have incredible capacity to protect themselves from harm."
 	icon = 'icons/obj/nt_melee.dmi'
-	icon_state = "nt_buckler" //by CeUvi we thx thy
+	icon_state = "nt_buckler"
 	item_state = "nt_buckler"
-	matter = list(MATERIAL_BIOMATTER = 15, MATERIAL_STEEL = 5, MATERIAL_PLASTEEL = 2, MATERIAL_GOLD = 1)
+	matter = list(MATERIAL_BIO_SILK = 15, MATERIAL_STEEL = 5, MATERIAL_CARBON_FIBER = 2, MATERIAL_GOLD = 1)
 	//aspects = list(SANCTIFIED) todo:port this
 	price_tag = 300
 	base_block_chance = 45

--- a/code/game/objects/items/weapons/storage.dm
+++ b/code/game/objects/items/weapons/storage.dm
@@ -1,13 +1,13 @@
 /obj/item/storage/sheath
 	name = "bonfire sheath"
-	desc = "Made to store only the swords of the church."
+	desc = "Made to store only the swords of the Custodians."
 	icon = 'icons/obj/sheath.dmi'
 
 	icon_state = "sheath"
 	item_state = "sheath"
 	slot_flags = SLOT_BELT
 	price_tag = 50
-	matter = list(MATERIAL_BIOMATTER = 5)
+	matter = list(MATERIAL_BIO_SILK = 5)
 	storage_slots = 1
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_HUGE

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -362,7 +362,7 @@
 	desc = "A medkit filled with a set of high-end trauma kits and anti-toxins."
 	icon_state = "nt_kit"
 	item_state = "nt_kit"
-	matter = list(MATERIAL_BIOMATTER = 5)
+	matter = list(MATERIAL_BIO_SILK = 5)
 
 /obj/item/storage/firstaid/nt/populate_contents()
 	if (empty) return

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -232,8 +232,8 @@ P.S - <u><h1>Don't leave the drills running unattended!</u></h1>"
 
 
 /obj/structure/noticeboard/church
-	name = "Church of the Bonfire bulletin board"
-	desc = "A board containing vital notices and official memos for the faithful"
+	name = "Custodians of Bonfire bulletin board"
+	desc = "A board containing vital notices and official memos for the Custodians."
 	icon_state = "nboard00"
 	notices = 0
 /*

--- a/code/modules/core_implant/cruciform/bible.dm
+++ b/code/modules/core_implant/cruciform/bible.dm
@@ -1,6 +1,6 @@
 /obj/item/book/ritual/cruciform
-	name = "Bonfire ritual book"
-	desc = "Contains holy litanies and religious prayers."
+	name = "Custodian guidance book"
+	desc = "Contains lectures for use by Custodians."
 	icon_state = "bible"
 	price_tag = 150
 
@@ -20,7 +20,7 @@
 	icon_state = "biblep"*/
 
 /obj/item/book/ritual/cruciform/priest
-	name = "Oathpledge ritual book"
-	desc = "Contains holy litany and prayers meant only for the Oathpledge."
+	name = "Oathpledge guidance book"
+	desc = "Contains lectures meant only for the Oathpledge."
 	icon_state = "biblep"
 	price_tag = 250

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -5,7 +5,7 @@ var/list/disciples = list()
 /obj/item/implant/core_implant/cruciform
 	name = "vinculum Hearthcore"
 	icon_state = "hearthcore_green"
-	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Church of Bonfire."
+	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Custodians."
 	allowed_organs = list(BP_CHEST)
 	implant_type = /obj/item/implant/core_implant/cruciform
 	layer = ABOVE_MOB_LAYER
@@ -228,7 +228,7 @@ var/list/disciples = list()
 /obj/item/implant/core_implant/cruciform/tessellate
 	name = "tessellate cruciform"
 	icon_state = "hearthcore_blue"
-	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Church of Bonfire."
+	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Custodians."
 	implant_type = /obj/item/implant/core_implant/cruciform/tessellate
 	power = 0
 	max_power = 60
@@ -238,7 +238,7 @@ var/list/disciples = list()
 /obj/item/implant/core_implant/cruciform/lemniscate
 	name = "lemniscate cruciform"
 	icon_state = "hearthcore_red"
-	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Church of Bonfire."
+	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Custodians."
 	implant_type = /obj/item/implant/core_implant/cruciform/lemniscate
 	//access = list(access_nt_disciple) //So they can try and recuit people - Correction people just cant stop abusing everything ever.
 	power = 0
@@ -249,7 +249,7 @@ var/list/disciples = list()
 /obj/item/implant/core_implant/cruciform/monomial
 	name = "monomial cruciform"
 	icon_state = "hearthcore_yellow"
-	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Church of Bonfire."
+	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Custodians."
 	implant_type = /obj/item/implant/core_implant/cruciform/monomial
 	power = 0
 	max_power = 90
@@ -259,7 +259,7 @@ var/list/disciples = list()
 /obj/item/implant/core_implant/cruciform/divisor
 	name = "divisor cruciform"
 	icon_state = "hearthcore_orange"
-	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Church of Bonfire."
+	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Custodians."
 	implant_type = /obj/item/implant/core_implant/cruciform/divisor
 	power = 0
 	max_power = 50
@@ -269,7 +269,7 @@ var/list/disciples = list()
 /obj/item/implant/core_implant/cruciform/factorial
 	name = "factorial cruciform"
 	icon_state = "hearthcore_cyan"
-	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Church of Bonfire."
+	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Custodians."
 	implant_type = /obj/item/implant/core_implant/cruciform/factorial
 	power = 0
 	max_power = 50
@@ -279,7 +279,7 @@ var/list/disciples = list()
 /obj/item/implant/core_implant/cruciform/omni
 	name = "Omni-Cruciform"
 	icon_state = "hearthcore_omni"
-	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Church of Bonfire."
+	desc = "A symbol and power core of every disciple. With the proper rituals, this can be implanted to induct a new believer into the Custodians."
 	implant_type = /obj/item/implant/core_implant/cruciform/omni
 	power = 0
 	max_power = 200

--- a/code/modules/organs/external/subtypes/robotic_types.dm
+++ b/code/modules/organs/external/subtypes/robotic_types.dm
@@ -282,10 +282,10 @@ obj/item/organ/external/robotic/synthskin/groin
 // Church of the Bonfire
 /obj/item/organ/external/robotic/church
 	name = "\"Bonfire\""
-	desc = "Gold and black prosthetics designed by the Church of the Bonfire."
+	desc = "Gold and black prosthetics designed by the Custodians."
 	force_icon = 'icons/mob/human_races/cyberlimbs/church.dmi'
 	model = "church"
-	matter = list(MATERIAL_STEEL = 15, MATERIAL_PLASTIC = 5, MATERIAL_BIOMATTER = 30)
+	matter = list(MATERIAL_STEEL = 15, MATERIAL_PLASTIC = 5, MATERIAL_CARBON_FIBER = 3)
 	price_tag = 400
 
 /obj/item/organ/external/robotic/church/l_arm

--- a/code/modules/organs/external/subtypes/robotic_types.dm
+++ b/code/modules/organs/external/subtypes/robotic_types.dm
@@ -285,7 +285,7 @@ obj/item/organ/external/robotic/synthskin/groin
 	desc = "Gold and black prosthetics designed by the Custodians."
 	force_icon = 'icons/mob/human_races/cyberlimbs/church.dmi'
 	model = "church"
-	matter = list(MATERIAL_STEEL = 15, MATERIAL_PLASTIC = 5, MATERIAL_CARBON_FIBER = 3)
+	matter = list(MATERIAL_STEEL = 15, MATERIAL_PLASTIC = 5, MATERIAL_BIO_SILK = 30)
 	price_tag = 400
 
 /obj/item/organ/external/robotic/church/l_arm


### PR DESCRIPTION
Adjusts a lot of church equipment strings (mostly weapons) to the updated Custodian strings based on their document, sprites still pending.

Adjusts Custodian-related things from using biomatter and plasteel to their bio-silk and carbon fiber.

Removes custodian base weapon item in-game and clearly spells out it is not to be used in case I missed another instance.
