### PR TITLE
atmos tweaks

### DIFF
--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -15,7 +15,7 @@
 
 	var/injecting = 0
 
-	var/volume_rate = 50	//flow rate limit
+	var/volume_rate = 200	//initial flow rate, tank computers can change this value
 
 	var/frequency = 0
 	var/id

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -7,7 +7,7 @@
 	desc = "Made by space amish using traditional space techniques, this heater is guaranteed not to set the colony on fire."
 	var/obj/item/cell/large/cell
 	var/on = 0
-	var/set_temperature = T0C + 50	//K
+	var/set_temperature = T0C + 40	//K
 	var/heating_power = 40000
 
 


### PR DESCRIPTION
too hot 🥵
also injectors tweak, all piping works at 200 liters, or 400 in case of the old filters, starting at 50 is asking to be clogged

## Changelog
:cl:
balance: makes space heaters a little less hot
tweak: injectors now start at 200 liters, from 50
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
