### PR TITLE
map tweaks and common sense

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -62,6 +62,7 @@
 #define PERK_NEAT /datum/perk/job/neat
 #define PERK_CHEF /datum/perk/foodappraise
 #define PERK_CLUB /datum/perk/job/club
+#define PERK_COMMON_SENSE /datum/perk/job/common_sense
 
 // Military
 #define PERK_CODESPEAK /datum/perk/job/codespeak

--- a/code/datums/perks/job.dm
+++ b/code/datums/perks/job.dm
@@ -118,6 +118,12 @@
 	perk_shared_ability = PERK_SHARED_SEE_ILLEGAL_REAGENTS
 	icon_state = "paper"
 
+/datum/perk/job/common_sense
+	name = "Common Sense"
+	desc = "You know what basic chemicals look like, from cleaning to cooking as well as the basics common chemicals."
+	perk_shared_ability = PERK_SHARED_SEE_COMMON_REAGENTS
+	icon_state = "paper"
+
 /datum/perk/job/junkborn
 	name = "Expert Scavenger"
 	desc = "One man's trash is another man's salary. Removing a trash pile has a chance of revealing a valuable item nobody else would find."

--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -20,7 +20,7 @@
 		STAT_VIG = 15,
 	)
 
-	perks = list(PERK_MARKET_PROF, PERK_CLUB)
+	perks = list(PERK_MARKET_PROF, PERK_CLUB, PERK_COMMON_SENSE)
 
 	outfit_type = /decl/hierarchy/outfit/job/service/clubmanager //Re-using this.
 	description = "The Bartender runs the colony bar, providing colonists with drinks and entertainment.<br>\
@@ -56,7 +56,7 @@
 		STAT_TGH = 10,
 	)
 
-	perks = list(PERK_MARKET_PROF, PERK_CLUB)
+	perks = list(PERK_MARKET_PROF, PERK_CLUB, PERK_COMMON_SENSE)
 
 	outfit_type = /decl/hierarchy/outfit/job/service/fixer
 	description = "The Fixer looks over the club, ensuring nobody skips on their bill or gets too handsy.<br>\
@@ -90,7 +90,7 @@
 	initial_balance = 750
 	wage = WAGE_LABOUR_DUMB //They should get paid by making food.
 
-	perks = list(PERK_CLUB, PERK_CHEF)
+	perks = list(PERK_CLUB, PERK_CHEF, PERK_COMMON_SENSE)
 
 	stat_modifiers = list(
 		STAT_ROB = 10,
@@ -129,7 +129,7 @@
 	health_modifier = 5
 	outfit_type = /decl/hierarchy/outfit/job/service/janitor
 
-	perks = list(PERK_JINGLE_JANGLE, PERK_NEAT)
+	perks = list(PERK_JINGLE_JANGLE, PERK_NEAT, PERK_COMMON_SENSE)
 
 	stat_modifiers = list(
 		STAT_ROB = 15,

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -352,8 +352,8 @@ var/global/chicken_count = 0
 		..()
 
 /mob/living/simple_animal/pig/hog
-	name = "Amerethi hog"
-	desc = "The result of crossing genetics between the colony's aging sow and cerberi from the Lodge, this is a docile species with asexual reproduction when fed mushrooms, raised chiefly for its meat without the otherwise ugly connotations of raising for slaughter what should have been a valued hunting companion."
+	name = "mycologist hog"
+	desc = "The result of crossing genetics of two into one! this breed of docile sus genus can asexual reproduction when fed mushrooms, raised chiefly for its meat."
 	icon_state = "pighog"
 
 /mob/living/simple_animal/pig/hog/attackby(var/obj/item/O as obj, var/mob/user as mob)

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -353,7 +353,7 @@ var/global/chicken_count = 0
 
 /mob/living/simple_animal/pig/hog
 	name = "mycologist hog"
-	desc = "The result of crossing genetics of two into one! this breed of docile sus genus can asexual reproduction when fed mushrooms, raised chiefly for its meat."
+	desc = "The result of crossing genetics, two into one! this breed of docile sus genus can perform asexual reproduction when fed mushrooms, raised chiefly for its meat."
 	icon_state = "pighog"
 
 /mob/living/simple_animal/pig/hog/attackby(var/obj/item/O as obj, var/mob/user as mob)

--- a/maps/__Liberty/map/_Liberty_Colony.dmm
+++ b/maps/__Liberty/map/_Liberty_Colony.dmm
@@ -997,6 +997,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
 "apf" = (
@@ -1064,6 +1068,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/crew_quarters/toilet/public{
 	name = "Lower Public Toilet"
@@ -1206,12 +1211,18 @@
 "arz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light,
+/obj/random/material/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
 "arE" = (
 /obj/machinery/petrel_maker,
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/liberty/engineering/engine_room)
+"arH" = (
+/obj/structure/table/rack/shelf,
+/obj/random/material_resources/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/rnd/research)
 "arJ" = (
 /obj/machinery/computer/rdconsole/robotics,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
@@ -1833,8 +1844,12 @@
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
 "aAn" = (
-/obj/random/furniture/pottedplant,
 /obj/machinery/camera/network/colony_underground{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/steel/monofloor{
@@ -2021,7 +2036,7 @@
 /area/liberty/security/sechall)
 "aDW" = (
 /obj/machinery/door/airlock/glass{
-	name = "R&D"
+	name = "Showers"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5857,11 +5872,8 @@
 /area/liberty/medical/surgery)
 "bFj" = (
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 1;
-	pixel_y = 3;
-	preloaded_reagents = list("plasma"=30)
-	},
+/obj/item/modular_computer/tablet/lease/preset/chemistry,
+/obj/item/device/scanner/mass_spectrometer/adv,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/medical/chemistry)
 "bFm" = (
@@ -6907,7 +6919,6 @@
 	},
 /obj/random/medical/low_chance,
 /obj/random/medical/low_chance,
-/obj/effect/floor_decal/industrial/warningred,
 /obj/item/reagent_containers/syringe/stim/greasy_lard{
 	pixel_x = 10
 	},
@@ -6923,6 +6934,9 @@
 	pixel_x = -5
 	},
 /obj/structure/table/reinforced,
+/obj/effect/floor_decal/industrial/warningred{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/medical/chemistry)
 "bSt" = (
@@ -7435,7 +7449,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/cafe,
 /area/liberty/rnd/lab)
 "bYF" = (
 /obj/machinery/vending/powermat,
@@ -7599,7 +7613,8 @@
 /obj/machinery/alarm{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/random/furniture/pottedplant,
+/turf/simulated/floor/tiled/cafe,
 /area/liberty/rnd/lab)
 "caH" = (
 /obj/machinery/telecomms/server/presets/blackshield,
@@ -7966,6 +7981,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
 "cfr" = (
@@ -8488,10 +8506,11 @@
 /area/liberty/security/sechall)
 "clV" = (
 /obj/structure/table/reinforced,
-/obj/item/modular_computer/tablet/lease/preset/chemistry,
-/obj/item/device/scanner/mass_spectrometer/adv,
 /obj/structure/noticeboard/medical{
 	pixel_x = -32
+	},
+/obj/machinery/chem_heater{
+	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/medical/chemistry)
@@ -9341,6 +9360,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/crew_quarters/toilet/public{
 	name = "Lower Public Toilet"
@@ -9434,12 +9454,23 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/bonfire/storage)
 "cxw" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/mob/living/simple_animal/cow,
-/turf/simulated/floor/asteroid/grass,
-/area/liberty/crew_quarters/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/hallway/side/f2section1)
 "cxS" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12601,6 +12632,12 @@
 "dmK" = (
 /turf/simulated/floor/tiled/dark/golden,
 /area/liberty/hallway/surface/section1)
+"dmR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/random/material_resources/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/rnd/research)
 "dmS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/network/security{
@@ -15119,6 +15156,10 @@
 	name = "murky water"
 	},
 /area/liberty/maintenance/undergroundfloor1west)
+"dWR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/liberty/rnd/lab)
 "dWT" = (
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 8
@@ -15317,6 +15358,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/liberty/crew_quarters/barbackroom)
@@ -15779,6 +15823,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/liberty/crew_quarters/barbackroom)
@@ -16347,7 +16394,6 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/engine_room)
 "eqK" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
 	pixel_y = 32
 	},
@@ -17263,6 +17309,9 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/light/small{
 	dir = 8
+	},
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/medical/sleeper)
@@ -18496,10 +18545,12 @@
 /turf/simulated/wall/r_wall,
 /area/liberty/rnd/docking)
 "eYK" = (
-/obj/structure/table/rack/shelf,
-/obj/random/circuitboard/low_chance,
-/obj/random/material/low_chance,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/table/rack,
+/obj/item/towel,
+/obj/item/towel,
+/obj/item/clothing/under/bathrobe,
+/obj/item/clothing/under/bathrobe,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/rnd/lab)
 "eYN" = (
 /obj/machinery/smartfridge/chemistry,
@@ -18512,10 +18563,7 @@
 /turf/simulated/floor/beach/water/shallow,
 /area/liberty/security/sechall)
 "eZh" = (
-/obj/structure/table/rack/shelf,
-/obj/random/material_resources,
-/obj/random/material/low_chance,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/cafe,
 /area/liberty/rnd/lab)
 "eZv" = (
 /obj/structure/grille,
@@ -18964,6 +19012,12 @@
 /area/liberty/security/prisoncells{
 	name = "Interrogation"
 	})
+"feV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/wood/wild3,
+/area/liberty/crew_quarters/barbackroom)
 "feY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -19554,7 +19608,7 @@
 /obj/machinery/atmospherics/unary/vent_pump{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/cafe,
 /area/liberty/rnd/lab)
 "fnh" = (
 /obj/machinery/door/firedoor,
@@ -21083,6 +21137,11 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/wood/wild2,
 /area/liberty/maintenance/undergroundfloor1east)
+"fIq" = (
+/obj/structure/table/reinforced,
+/obj/random/material/low_chance,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/rnd/research)
 "fIA" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -21094,14 +21153,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
 "fII" = (
-/obj/structure/table/rack/shelf,
-/obj/random/material_rare/low_chance,
-/obj/random/material/low_chance,
-/obj/machinery/camera/network/research{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/rnd/lab)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/dinnerware,
+/turf/simulated/floor/tiled/steel/bar_flat,
+/area/liberty/crew_quarters/barbackroom)
 "fIJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/green{
@@ -21243,6 +21298,8 @@
 /obj/machinery/camera/network/research{
 	dir = 1
 	},
+/obj/random/material_resources,
+/obj/random/material_rare/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
 "fLe" = (
@@ -22151,9 +22208,11 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor1west)
 "fWZ" = (
-/obj/structure/sign/warning/nosmoking/small,
-/turf/simulated/wall,
-/area/liberty/medical/sleeper)
+/mob/living/simple_animal/cow{
+	name = "Betsy"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/liberty/crew_quarters/hydroponics)
 "fXa" = (
 /obj/structure/table/reinforced,
 /obj/item/device/lighting/toggleable/lamp,
@@ -24589,13 +24648,14 @@
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/liberty/maintenance/undergroundfloor1east)
 "gGN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/hallway/side/f2section1)
@@ -25535,7 +25595,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/cafe,
 /area/liberty/rnd/lab)
 "gSq" = (
 /obj/structure/table/woodentable,
@@ -27399,6 +27459,14 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/industrial/navy_large_slates,
 /area/liberty/maintenance/undergroundfloor1south)
+"htR" = (
+/obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/wood/wild3,
+/area/liberty/crew_quarters/bar)
 "htT" = (
 /obj/structure/bookcase,
 /obj/item/book/ritual/cruciform,
@@ -28737,10 +28805,13 @@
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/atmos)
 "hKE" = (
-/obj/structure/table/rack/shelf,
-/obj/random/material_resources,
-/obj/random/material_resources/low_chance,
-/turf/simulated/floor/tiled/dark,
+/obj/structure/curtain/open/shower,
+/obj/item/stool,
+/obj/structure/window/basic{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/rnd/lab)
 "hKH" = (
 /turf/simulated/shuttle/wall/science{
@@ -30383,6 +30454,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/white,
 /area/liberty/maintenance/undergroundfloor1east)
+"ikX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/liberty/rnd/lab)
 "ilm" = (
 /obj/machinery/computer/rdconsole/robotics,
 /obj/structure/cable/green{
@@ -30560,6 +30636,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/lab)
 "iop" = (
@@ -33772,6 +33852,15 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/liberty/engineering/foyer)
+"jfS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/rnd/lab)
 "jgj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holoposter{
@@ -33844,10 +33933,11 @@
 /turf/simulated/floor/asteroid/grass/jungle,
 /area/liberty/maintenance/northcave)
 "jhd" = (
+/obj/structure/table/rack/shelf,
+/obj/random/material_rare/low_chance,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/table/rack/shelf,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
 "jhs" = (
@@ -34638,10 +34728,6 @@
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/security/sechall)
 "jsN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -34649,6 +34735,10 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/crew_quarters/sleep/cryo2)
 "jsP" = (
@@ -35049,6 +35139,9 @@
 /obj/machinery/light_switch{
 	dir = 4;
 	pixel_x = -25
+	},
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_x = -36
 	},
 /turf/simulated/floor/tiled/white/monofloor,
 /area/liberty/medical/chemistry)
@@ -36253,10 +36346,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
 "jSc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -36269,6 +36358,10 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/lab)
 "jSd" = (
@@ -37264,6 +37357,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/hallway/side/f2section1)
+"ker" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/medical/medeva)
 "keB" = (
 /turf/simulated/shuttle/wall/mining{
 	icon_state = "10,15"
@@ -37494,6 +37601,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/crew_quarters/toilet/public{
 	name = "Lower Public Toilet"
@@ -38453,6 +38561,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
 "kvg" = (
@@ -38741,9 +38850,8 @@
 /turf/simulated/floor/tiled/techmaint_perforated,
 /area/liberty/maintenance/undergroundfloor1west)
 "kyY" = (
-/obj/structure/table/rack/shelf,
-/obj/random/material_rare/low_chance,
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/washing_machine,
+/turf/simulated/floor/tiled/white/techfloor,
 /area/liberty/rnd/lab)
 "kzd" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -41392,6 +41500,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1west)
+"los" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/white/gray_perforated,
+/area/liberty/crew_quarters/sleep/cryo2)
 "lov" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
 /obj/effect/decal/cleanable/dirt,
@@ -41686,6 +41806,9 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/liberty/crew_quarters/barbackroom)
@@ -44553,6 +44676,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/liberty/hallway/side/f2section1)
 "mhw" = (
@@ -45758,6 +45886,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel,
 /area/liberty/quartermaster/hangarsupply)
+"mDN" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/mob/living/simple_animal/chicken{
+	name = "Commander Clucky"
+	},
+/turf/simulated/floor/asteroid/grass,
+/area/liberty/crew_quarters/hydroponics)
 "mEx" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 1;
@@ -46991,6 +47128,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
 "mVv" = (
@@ -47813,7 +47951,6 @@
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
 	},
-/obj/machinery/door/firedoor/multi_tile,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -52166,9 +52303,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/holoposter{
-	pixel_y = -32
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
 "opO" = (
@@ -52565,6 +52700,8 @@
 /area/liberty/rnd/robotics)
 "ovp" = (
 /obj/structure/table/rack/shelf,
+/obj/random/circuitboard/low_chance,
+/obj/random/material/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
 "ovs" = (
@@ -53626,6 +53763,23 @@
 /obj/item/trash/material/device,
 /turf/simulated/floor/tiled/techmaint,
 /area/liberty/maintenance/undergroundfloor1west)
+"oJI" = (
+/obj/item/stool/custom/bar_special,
+/obj/effect/floor_decal/border/carpet/purple{
+	dir = 1
+	},
+/obj/effect/floor_decal/border/carpet/purple{
+	dir = 4
+	},
+/obj/effect/floor_decal/border/carpet/purple{
+	dir = 5
+	},
+/obj/structure/sign/warning/smoking/small{
+	pixel_x = 32;
+	pixel_y = 6
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/liberty/crew_quarters/bar)
 "oJP" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/asteroid/grass,
@@ -55212,6 +55366,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/liberty/crew_quarters/toilet/public{
 	name = "Lower Public Toilet"
@@ -56748,6 +56903,10 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/liberty/crew_quarters/barbackroom)
@@ -59159,6 +59318,14 @@
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/liberty/crew_quarters/kitchen)
+"qhc" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -32
+	},
+/obj/machinery/suit_storage_unit,
+/turf/simulated/floor/tiled/cafe,
+/area/liberty/rnd/lab)
 "qhm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -59891,6 +60058,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/crew_quarters/sleep/cryo2)
 "qql" = (
@@ -60139,9 +60309,14 @@
 /turf/simulated/floor/wood/wild3,
 /area/liberty/hallway/surface/section1)
 "qua" = (
-/obj/structure/table/rack/shelf,
-/obj/random/material_resources/low_chance,
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/corner_techfloor_grid{
+	dir = 1
+	},
+/obj/structure/curtain/open/shower,
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/liberty/rnd/lab)
 "quf" = (
 /turf/simulated/floor/rock,
@@ -60462,6 +60637,21 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/liberty/engineering/engine_room)
+"qzL" = (
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_y = -32
+	},
+/turf/simulated/floor/tiled/white,
+/area/liberty/medical/sleeper)
 "qzX" = (
 /obj/structure/noticeboard/prospectors,
 /turf/simulated/wall/r_wall,
@@ -62780,7 +62970,6 @@
 /obj/machinery/door/blast/regular/open{
 	id = "Colony Lockdown"
 	},
-/obj/machinery/door/firedoor/multi_tile,
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -63229,6 +63418,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/liberty/crew_quarters/barbackroom)
@@ -64006,6 +64198,10 @@
 /obj/machinery/atm{
 	pixel_y = 32
 	},
+/obj/structure/sign/warning/nosmoking/small{
+	pixel_x = -32;
+	pixel_y = 32
+	},
 /turf/simulated/floor/tiled/white,
 /area/liberty/medical/sleeper)
 "rxX" = (
@@ -64458,6 +64654,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
 "rFd" = (
@@ -64476,9 +64673,12 @@
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters)
 "rFw" = (
+/obj/machinery/light{
+	dir = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/cafe,
 /area/liberty/rnd/lab)
 "rFH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -64571,6 +64771,13 @@
 /area/liberty/maintenance/undergroundfloor1north)
 "rGP" = (
 /obj/structure/table/standard,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/honey_frame,
+/obj/item/bee_pack,
+/obj/item/bee_smoker,
+/obj/item/tool/crowbar/improvised,
+/obj/item/beehive_assembly,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/crew_quarters/hydroponics)
 "rGQ" = (
@@ -65914,6 +66121,16 @@
 /obj/effect/spider/stickyweb,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/liberty/maintenance/undergroundfloor1east)
+"saz" = (
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/crew_quarters/toilet/public{
+	name = "Lower Public Toilet"
+	})
 "saA" = (
 /turf/simulated/floor/wood/wild5,
 /area/liberty/dungeon/outside/campground)
@@ -66214,13 +66431,9 @@
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/liberty/security)
 "sdj" = (
-/obj/structure/table/rack/shelf,
-/obj/random/material_resources/low_chance,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/liberty/rnd/lab)
+/mob/living/simple_animal/pig/hog,
+/turf/simulated/floor/asteroid/grass,
+/area/liberty/crew_quarters/hydroponics)
 "sdI" = (
 /obj/structure/table/woodentable,
 /obj/item/device/camera,
@@ -68809,6 +69022,7 @@
 	dir = 4;
 	pixel_x = 30
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
 "sKg" = (
@@ -72786,17 +73000,22 @@
 /turf/simulated/floor/tiled/white/monofloor,
 /area/liberty/medical/chemistry)
 "tPn" = (
-/obj/item/reagent_containers/dropper{
-	pixel_y = -4
-	},
 /obj/item/storage/box/syringes{
 	pixel_x = 3;
 	pixel_y = 3
 	},
 /obj/item/storage/box/beakers,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/item/tool/screwdriver,
 /obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/beaker{
+	pixel_x = 1;
+	pixel_y = 3;
+	preloaded_reagents = list("plasma"=30)
+	},
+/obj/item/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/obj/item/tool/screwdriver,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/medical/chemistry)
 "tPz" = (
@@ -73309,6 +73528,25 @@
 /obj/random/booze/low_chance,
 /turf/simulated/floor/tiled/cafe,
 /area/liberty/crew_quarters/dorm3)
+"tWX" = (
+/obj/effect/floor_decal/spline/plain{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/liberty/crew_quarters/bar)
 "tWY" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -74184,6 +74422,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/concrete_bricks,
 /area/liberty/maintenance/undergroundfloor1east)
+"uiB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/liberty/medical/medeva)
 "uiC" = (
 /obj/random/material,
 /obj/machinery/conveyor/east,
@@ -75041,6 +75288,7 @@
 /area/liberty/engineering/engine_room)
 "uve" = (
 /obj/structure/table/reinforced,
+/obj/random/material_resources,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
 "uvo" = (
@@ -75195,6 +75443,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
+/obj/random/material_resources/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
 "uxB" = (
@@ -76608,6 +76857,11 @@
 /obj/machinery/holoposter{
 	pixel_y = -32
 	},
+/obj/machinery/disposal,
+/obj/effect/floor_decal/industrial/box/red,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/liberty/engineering/workshop)
 "uSt" = (
@@ -77015,9 +77269,6 @@
 /turf/simulated/floor/industrial/white_large_slates,
 /area/liberty/maintenance/undergroundfloor1west)
 "vaQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
@@ -77028,6 +77279,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/liberty/engineering/workshop)
 "vaV" = (
@@ -77145,7 +77400,10 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/mob/living/simple_animal/pig,
+/mob/living/simple_animal/pig{
+	desc = "This intelligent sow has strange, pointy ears.";
+	name = "Becka"
+	},
 /turf/simulated/floor/asteroid/grass,
 /area/liberty/crew_quarters/hydroponics)
 "vbY" = (
@@ -77599,14 +77857,9 @@
 /turf/simulated/floor/industrial/ornate,
 /area/liberty/maintenance/undergroundfloor1north)
 "vjf" = (
-/obj/machinery/chemical_dispenser,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 32;
-	pixel_y = -5
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/liberty/medical/chemistry)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/tiled/cafe,
+/area/liberty/rnd/lab)
 "vjk" = (
 /obj/machinery/r_n_d/server/robotics,
 /turf/simulated/floor/bluegrid{
@@ -78010,6 +78263,11 @@
 	dir = 4
 	},
 /area/liberty/security/vacantoffice2)
+"voA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharge_station,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/liberty/medical/sleeper)
 "voN" = (
 /obj/machinery/door/firedoor/multi_tile,
 /obj/effect/decal/cleanable/dirt,
@@ -81386,11 +81644,11 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/engine_room)
 "wiQ" = (
-/obj/machinery/vending/fitness,
 /obj/machinery/light,
 /obj/machinery/holoposter{
 	pixel_y = -32
 	},
+/obj/machinery/vending/dinnerware/cost,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/liberty/hallway/side/f2section1)
 "wiS" = (
@@ -81755,10 +82013,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/liberty/maintenance/undergroundfloor1north)
 "wor" = (
-/obj/machinery/chem_heater{
-	pixel_y = 4
-	},
 /obj/structure/table/reinforced,
+/obj/structure/sink,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/liberty/medical/chemistry)
 "woy" = (
@@ -82733,7 +82989,6 @@
 /turf/simulated/floor/wood,
 /area/liberty/command/cso)
 "wCh" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -82746,6 +83001,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
 "wCj" = (
@@ -83105,6 +83363,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
@@ -85040,6 +85302,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/hallway/side/f2section1)
 "xiN" = (
@@ -85077,6 +85340,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/dark,
+/area/liberty/rnd/research)
+"xiX" = (
+/obj/structure/table/reinforced,
+/obj/random/material_resources/low_chance,
+/obj/random/circuitboard/low_chance,
 /turf/simulated/floor/tiled/dark,
 /area/liberty/rnd/research)
 "xjc" = (
@@ -86829,6 +87098,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/industrial/green_large_slates,
 /area/liberty/maintenance/undergroundfloor1east)
+"xIr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood/wild3,
+/area/liberty/crew_quarters/barbackroom)
 "xIK" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -86857,6 +87140,14 @@
 /obj/effect/decal/cleanable/rubble,
 /turf/simulated/floor/beach/water/ice,
 /area/liberty/maintenance/undergroundfloor1north)
+"xIW" = (
+/obj/effect/floor_decal/industrial/box/red,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor/wood/wild3,
+/area/liberty/crew_quarters/barbackroom)
 "xJd" = (
 /obj/machinery/door/airlock/command{
 	name = "Secretary's Office";
@@ -87369,6 +87660,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/liberty/crew_quarters/sleep/cryo2)
 "xQL" = (
@@ -87501,6 +87796,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/wood/wild3,
 /area/liberty/crew_quarters/bar)
@@ -141404,14 +141703,14 @@ wCp
 fxu
 wCp
 xQB
-lwp
-lwp
+los
+los
 kiz
 pfU
 pfU
 cwx
 apQ
-iYk
+saz
 lgE
 emu
 emu
@@ -143397,7 +143696,7 @@ lYo
 lYo
 lYo
 lYo
-fvP
+cxw
 tZi
 eAa
 xou
@@ -143599,7 +143898,7 @@ keS
 uIW
 uIW
 lYo
-fvP
+cxw
 noo
 mDk
 mDk
@@ -143801,7 +144100,7 @@ dsk
 urg
 uIW
 wqB
-fvP
+cxw
 xmn
 mDk
 nvr
@@ -144003,7 +144302,7 @@ sLi
 wgG
 uIW
 lYo
-fvP
+cxw
 noo
 qlM
 ndB
@@ -144036,7 +144335,7 @@ dTi
 huE
 kYQ
 jhd
-ovp
+arH
 ovp
 dYU
 gcq
@@ -144407,7 +144706,7 @@ sLi
 wgG
 uIW
 lYo
-fvP
+cxw
 noo
 mDk
 nYi
@@ -144609,7 +144908,7 @@ mmJ
 qTp
 uIW
 fvx
-fvP
+cxw
 noo
 svh
 sAa
@@ -144641,8 +144940,8 @@ dYU
 uFF
 xxf
 fqI
-uve
-uve
+fIq
+fIq
 arz
 dYU
 jZb
@@ -144811,7 +145110,7 @@ uIW
 uIW
 uIW
 sme
-fvP
+cxw
 noo
 rBU
 ani
@@ -145228,7 +145527,7 @@ kvc
 kvc
 kvc
 kvc
-kvc
+tWX
 ueb
 uEF
 eLk
@@ -145430,7 +145729,7 @@ isu
 isu
 isu
 mwX
-djn
+htR
 jvq
 pBu
 hAo
@@ -145466,11 +145765,11 @@ bXb
 szr
 gcv
 xsb
-whf
-qua
-fII
 hKE
-whf
+qua
+xsb
+hKE
+qua
 xsb
 xUk
 gUa
@@ -145669,10 +145968,10 @@ pGF
 jGu
 xsb
 eYK
-qPF
-qPF
-qPF
-qua
+dWR
+xsb
+eYK
+dWR
 djF
 xUk
 gUa
@@ -145854,8 +146153,8 @@ ruz
 huE
 fqI
 uxz
-uve
-arz
+xiX
+dmR
 jDd
 whf
 xUk
@@ -145870,10 +146169,10 @@ bXb
 shE
 ykO
 hiR
-sdj
-qPF
+eZh
+vjf
 rFw
-qPF
+vjf
 eZh
 djF
 xUk
@@ -146072,10 +146371,10 @@ bXb
 huX
 piD
 xsb
-eYK
-qPF
-rFw
-qPF
+kyY
+vjf
+ikX
+vjf
 kyY
 djF
 xDb
@@ -146278,7 +146577,7 @@ cax
 bYt
 gSn
 fng
-acq
+qhc
 xsb
 gwL
 bkK
@@ -146635,7 +146934,7 @@ pxd
 oAJ
 pBJ
 lsy
-dLp
+xIr
 knV
 dLp
 jzh
@@ -146837,7 +147136,7 @@ pxd
 jXL
 vWC
 rzj
-yis
+feV
 ppy
 ozj
 qmO
@@ -146850,7 +147149,7 @@ djn
 djn
 pbN
 sDA
-rgp
+oJI
 xsS
 qlM
 cFe
@@ -147039,7 +147338,7 @@ pxd
 sum
 lTS
 bWz
-yis
+xIW
 pxd
 pxd
 qCV
@@ -147089,7 +147388,7 @@ qPF
 qPF
 qPF
 hmm
-qPF
+jfS
 hGS
 eQo
 tlH
@@ -147243,7 +147542,7 @@ pxd
 pxd
 pxd
 pxd
-sbQ
+fII
 qhS
 eon
 pxd
@@ -148079,7 +148378,7 @@ cpB
 smk
 ylm
 fEh
-vjf
+guS
 bVt
 bFj
 bVt
@@ -148902,7 +149201,7 @@ pcF
 dQy
 pcF
 dpV
-yge
+ker
 yge
 wPk
 xNg
@@ -149092,7 +149391,7 @@ rxW
 ioE
 ozn
 xkM
-fWZ
+xkM
 ajd
 ajd
 xkM
@@ -149102,9 +149401,9 @@ hWQ
 iIq
 eJw
 eRS
-eJw
+voA
 eOr
-fHr
+uiB
 fHr
 oCz
 xtA
@@ -150310,7 +150609,7 @@ lnX
 uwy
 wmH
 unr
-pnM
+qzL
 lBc
 rYz
 llm
@@ -190481,8 +190780,8 @@ wmf
 iWJ
 vlc
 vhK
-uQB
-pJI
+mDN
+fWZ
 oGp
 bII
 diE
@@ -190683,7 +190982,7 @@ cIU
 cIU
 cIU
 cIU
-cxw
+uQB
 tCM
 pWa
 bII
@@ -190886,7 +191185,7 @@ wfC
 cIU
 cIU
 ewu
-pWa
+sdj
 xEG
 bII
 bhK


### PR DESCRIPTION
Reallows club workers to see common reagents
Adds 2 more dinnerware venders
Adds more trash cans around the lower areas
moves around some no smoking signs to no longer overlap into public areas 
fixes stacked airlock issues
Fixed some missing named pets
Fixed missing hog for garden
Renames hog to be more lore-friendly 