### PR TITLE
the bridge to 515

### DIFF
--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -1,0 +1,63 @@
+// This file contains defines allowing targeting byond versions newer than the supported
+
+//Update this whenever you need to take advantage of more recent byond features
+#define MIN_COMPILER_VERSION 514
+#define MIN_COMPILER_BUILD 1556
+#if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
+//Don't forget to update this part
+#error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
+#error You need version 514.1556 or higher
+#endif
+
+#if (DM_VERSION == 514 && DM_BUILD > 1575 && DM_BUILD <= 1577)
+#error Your version of BYOND currently has a crashing issue that will prevent you from running Dream Daemon test servers.
+#error We require developers to test their content, so an inability to test means we cannot allow the compile.
+#error Please consider downgrading to 514.1575 or lower.
+#endif
+
+// Keep savefile compatibilty at minimum supported level
+#if DM_VERSION >= 515
+/savefile/byond_version = MIN_COMPILER_VERSION
+#endif
+
+// 515 split call for external libraries into call_ext
+#if DM_VERSION < 515
+#define LIBCALL call
+#else
+#define LIBCALL call_ext
+#endif
+
+// So we want to have compile time guarantees these methods exist on local type, unfortunately 515 killed the .proc/procname and .verb/verbname syntax so we have to use nameof()
+// For the record: GLOBAL_VERB_REF would be useless as verbs can't be global.
+
+#if DM_VERSION < 515
+
+/// Call by name proc references, checks if the proc exists on either this type or as a global proc.
+#define PROC_REF(X) (.proc/##X)
+/// Call by name verb references, checks if the verb exists on either this type or as a global verb.
+#define VERB_REF(X) (.verb/##X)
+
+/// Call by name proc reference, checks if the proc exists on either the given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) (##TYPE.proc/##X)
+/// Call by name verb reference, checks if the verb exists on either the given type or as a global verb
+#define TYPE_VERB_REF(TYPE, X) (##TYPE.verb/##X)
+
+/// Call by name proc reference, checks if the proc is an existing global proc
+#define GLOBAL_PROC_REF(X) (/proc/##X)
+
+#else
+
+/// Call by name proc references, checks if the proc exists on either this type or as a global proc.
+#define PROC_REF(X) (nameof(.proc/##X))
+/// Call by name verb references, checks if the verb exists on either this type or as a global verb.
+#define VERB_REF(X) (nameof(.verb/##X))
+
+/// Call by name proc reference, checks if the proc exists on either the given type or as a global proc
+#define TYPE_PROC_REF(TYPE, X) (nameof(##TYPE.proc/##X))
+/// Call by name verb reference, checks if the verb exists on either the given type or as a global verb
+#define TYPE_VERB_REF(TYPE, X) (nameof(##TYPE.verb/##X))
+
+/// Call by name proc reference, checks if the proc is an existing global proc
+#define GLOBAL_PROC_REF(X) (/proc/##X)
+
+#endif

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -51,15 +51,6 @@
 #define FORCE_MAP "_maps/runtimestation.json"
 #endif
 
-//Update this whenever you need to take advantage of more recent byond features
-#define MIN_COMPILER_VERSION 514
-#define MIN_COMPILER_BUILD 1556
-#if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
-//Don't forget to update this part
-#error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 514.1556 or higher
-#endif
-
 //Additional code for the above flags.
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.

--- a/liberty-station.dme
+++ b/liberty-station.dme
@@ -7,6 +7,7 @@
 #define DEBUG
 // END_PREFERENCES
 // BEGIN_INCLUDE
+#include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_debugger.dm"
 #include "code\client_macros.dm"


### PR DESCRIPTION
this file is mostly defines that allow us to slowly upgrade to 515 while operating as 514
it only really matters to coders right now, so 🤷 
the new file was taken from TG, adapted to our codebase by me

## Changelog
:cl:
code: more stuff to allow us to code in 515 while operating in 514
<!--add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know-->
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
