### PR TITLE
Gun fixes 2.0

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic/duty.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/duty.dm
@@ -42,7 +42,7 @@
 	icon_state = "frame_ak"
 	matter = list(MATERIAL_PLASTEEL = 8)
 	result = /obj/item/gun/projectile/automatic/duty
-	gripvars = list(/obj/item/part/gun/grip/black)
+	gripvars = list(/obj/item/part/gun/grip/wood)
 	resultvars = list(/obj/item/gun/projectile/automatic/duty)
 	mechanismvar = /obj/item/part/gun/mechanism/autorifle
 	barrelvars = list(/obj/item/part/gun/barrel/srifle)

--- a/code/modules/projectiles/guns/projectile/automatic/lmg.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/lmg.dm
@@ -154,7 +154,7 @@
 	resultvars = list(/obj/item/gun/projectile/automatic/lmg/buzzsaw, /obj/item/gun/projectile/automatic/lmg/hog)
 	gripvars = list(/obj/item/part/gun/grip/black, /obj/item/part/gun/grip/rubber)
 	mechanismvar = /obj/item/part/gun/mechanism/machinegun
-	barrelvars = list(/obj/item/part/gun/barrel/srifle, /obj/item/part/gun/barrel/lrifle)
+	barrelvars = list(/obj/item/part/gun/barrel/srifle)
 
 /obj/item/gun/projectile/automatic/lmg/tk/update_icon()
 //	..() We are rather different than other guns and lmgs.
@@ -198,7 +198,7 @@
 	item_state = "hog"
 	fire_sound = 'sound/weapons/guns/fire/heroic_fire.ogg'
 	fire_sound_silenced = 'sound/weapons/guns/fire/silenced_mg.ogg' // Yay snowflake silenced sound!
-	caliber = CAL_RIFLE
+	caliber = CAL_SRIFLE
 	damage_multiplier = 1.2 // With full auto penalties in mind (20%) this becomes a normal x1 damage modifier.
 	penetration_multiplier = 1.0
 	init_recoil = HMG_RECOIL(0.6) // Better slap a bipod on this one! Impossible to fire steady if not braced.
@@ -210,7 +210,7 @@
 		BURST_8_ROUND,
 		FULL_AUTO_600 // Meant to be a supressive fire GPMG
 		)
-	gun_parts = list(/obj/item/part/gun/frame/buzzsaw = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/machinegun = 1, /obj/item/part/gun/barrel/lrifle = 1)
+	gun_parts = list(/obj/item/part/gun/frame/buzzsaw = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/machinegun = 1, /obj/item/part/gun/barrel/srifle = 1)
 
 // Even more special than the Takeshi so we have to do this all over again instead of being a Takeshi child
 /obj/item/gun/projectile/automatic/lmg/hog/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic/nationale.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/nationale.dm
@@ -94,7 +94,7 @@
 	extra_damage_mult_scoped = 0.2
 	zoom_factors = list(0.8)
 
-	gun_parts = list(/obj/item/part/gun/frame/nationale = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/srifle = 1)
+	gun_parts = list(/obj/item/part/gun/frame/nationale = 1, /obj/item/part/gun/grip/rubber = 1, /obj/item/part/gun/mechanism/autorifle = 1, /obj/item/part/gun/barrel/lrifle = 1)
 
 	init_firemodes = list(
 		BURST_3_ROUND,

--- a/code/modules/projectiles/guns/projectile/automatic/tactical.dm
+++ b/code/modules/projectiles/guns/projectile/automatic/tactical.dm
@@ -35,7 +35,7 @@
 	resultvars = list(/obj/item/gun/projectile/automatic/tactical)
 	gripvars = list(/obj/item/part/gun/grip/rubber)
 	mechanismvar = /obj/item/part/gun/mechanism/smg
-	barrelvars = list(/obj/item/part/gun/barrel/pistol)
+	barrelvars = list(/obj/item/part/gun/barrel/magnum)
 
 /obj/item/gun/projectile/automatic/tactical/update_icon()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Here we go again.
Duty rifle grip mismatch fixed, now takes wooden grips and can be crafted.
Dragon marksman rifle variant of the Nationale rifle now takes 7.62 barrels and can be crafted.
Tactical SMG now takes 10mm barrels and can be crafted.
Hog LMG is now properly 6.5mm.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
fix: Duty frame and gun mismatched grips fixed, frame now takes wood
fix: Nationale dragon barrel switched from srifle to lrifle
fix: Tactical SMG switched barrels from pistol to magnum
fix: Hog LMG removed instances of lrifle and CAL_RIFLE, now srifle and CAL_SRIFLE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
