### PR TITLE
Fixes faulty spawn behavior

### DIFF
--- a/code/game/objects/landmarks/join.dm
+++ b/code/game/objects/landmarks/join.dm
@@ -47,7 +47,8 @@ GLOBAL_LIST_EMPTY(spawntypes)
 	join_tag = "starboard_late_cryo"
 	message = null
 	spawn_datum_type = /datum/spawnpoint/cryo/outsider
-	disallow_job = list(JOBS_OVERALL)
+	disallow_job = null
+	restrict_job = list("Outsider")
 
 /obj/landmark/join/late/cryo/starboard
 	name = "Starboard Cryogenic Storage"

--- a/maps/_DeepForest/map/frozen_crashsite.dmm
+++ b/maps/_DeepForest/map/frozen_crashsite.dmm
@@ -529,7 +529,7 @@
 /turf/simulated/floor/snow,
 /area/liberty/dungeon/outside/frozen_forest/crashsite)
 "gw" = (
-/obj/landmark/join/late/dormitory_outsider,
+/obj/landmark/join/late/cryo/outsider,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/cryopod/dormitory,
 /turf/simulated/floor/wood/wild4,
@@ -2790,7 +2790,7 @@
 /turf/simulated/floor/snow,
 /area/liberty/dungeon/outside/frozen_forest/crashsite)
 "Fu" = (
-/obj/landmark/join/late/dormitory_outsider,
+/obj/landmark/join/late/cryo/outsider,
 /obj/machinery/cryopod/dormitory,
 /turf/simulated/floor/wood/wild4,
 /area/liberty/dungeon/outside/abandoned_outpost)
@@ -3156,7 +3156,7 @@
 /turf/simulated/floor/rock/dark,
 /area/colony)
 "Jt" = (
-/obj/landmark/join/late/dormitory_outsider,
+/obj/landmark/join/late/cryo/outsider,
 /obj/machinery/cryopod/dormitory,
 /turf/simulated/floor/wood/wild4,
 /area/liberty/dungeon/outside/farm)


### PR DESCRIPTION
Changing disallow_job out for restrict_job since it's more reliable. Think the disallow_job check has bad logic since it refused even Outsiders and did not refuse colony jobs from spawning.

Of note is that no spawn points exist for Outsider Bed, everything "outsider" is in old-cyro-spawn, but I don't even know how I'd fix that.

Tested on a local copy up-to-date to the point #298 was merged, late-joined as Outsider on colony spawn points, was refused and it randomly checked spawn points until it reached old-cyro-spawn and let me through.

Late-joined as Colonist on Outsider spawn points, it refused and checked until it found one that would allow me. (lower elevator, cryo, etc)

Didn't test Robot that much but there should be no problem since restrict_job seems to work well.