### PR TITLE
Eris Wielding and QOL Port

### DIFF
--- a/code/game/objects/items/_inventory.dm
+++ b/code/game/objects/items/_inventory.dm
@@ -130,30 +130,36 @@
 
 /obj/item/MouseDrop(obj/over_object)
 	if(item_flags & DRAG_AND_DROP_UNEQUIP && isliving(usr))
-		if(try_uneqip(over_object, usr))
+		if(try_transfer(over_object, usr))
 			return
 	return ..()
 
 
-/obj/item/proc/try_uneqip(target, mob/living/user)
+/obj/item/proc/try_transfer(target, mob/living/user)
 	if(loc == user && ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if (!istype(target, /obj/screen/inventory/hand))
-			return
-
+		if(istype(target, /obj/screen/inventory))
+			var/obj/screen/inventory/screen_thing = target
+			target = screen_thing.slot_id
 		//makes sure that the storage is equipped, so that we can't drag it into our hand from miles away.
 		//there's got to be a better way of doing this.
 		if(src.loc != H || H.incapacitated())
-			return
-
-		if (!H.unEquip(src))
-			return
-
-		var/obj/screen/inventory/hand/Hand = target
-		switch(Hand.slot_id)
-			if(slot_r_hand)
-				H.put_in_r_hand(src)
-			if(slot_l_hand)
-				H.put_in_l_hand(src)
-		src.add_fingerprint(usr)
+			return FALSE
+		if(!H.canUnEquip(src))
+			return FALSE
+		if(!H.can_equip(src, target, FALSE, FALSE, FALSE))
+			return FALSE
+		H.remove_from_mob(src, FALSE)
+		/*
+			Copied from human equip_to_slot
+			Separate since its needed to prevent double-signals being sent
+			on atom containerization
+		*/
+		H.equip_to_slot(src, target, TRUE, FALSE)
+		if(H.client)
+			H.client.screen |= src
+		if(action_button_name)
+			H.update_action_buttons()
+		if(H.get_holding_hand(src))
+			add_hud_actions(H)
 		return TRUE

--- a/code/game/objects/items/wielding.dm
+++ b/code/game/objects/items/wielding.dm
@@ -11,9 +11,14 @@
 
 /mob/living/proc/do_wield()//The proc we actually care about.
 	var/obj/item/I = get_active_hand()
+	var/obj/item/O = get_inactive_hand()
 	if(!I)
-		return
-	I.attempt_wield(src)
+		if(!O)
+			return
+		swap_hand()
+		O.attempt_wield(src)
+	else
+		I.attempt_wield(src)
 
 /obj/item/proc/unwield(mob/living/user)
 	if(!wielded || !user)
@@ -47,9 +52,12 @@
 		return
 	if(!is_held_twohanded(user))
 		return
-	if(user.get_inactive_hand())
-		to_chat(user, SPAN_WARNING("You need your other hand to be empty!</span>"))
-		return
+	var/obj/item/X = user.get_inactive_hand()
+	if(X)
+		if(!X.canremove)
+			return
+		user.drop_offhand()
+		to_chat(user, SPAN_WARNING("You dropped \the [X]."))
 	wielded = TRUE
 	if(force_wielded)
 		force = force_wielded
@@ -100,9 +108,9 @@
 
 /obj/item/proc/is_held_twohanded(mob/living/M)
 	var/check_hand
-	if(M.l_hand == src && !M.r_hand)//Eris removed hands long ago. This would normally check hands but it has to check if you have arms instead. Otherwise the below comments would be accurate.
+	if(M.l_hand == src)//Eris removed hands long ago. This would normally check hands but it has to check if you have arms instead. Otherwise the below comments would be accurate.
 		check_hand = BP_R_ARM //item in left hand, check right hand
-	else if(M.r_hand == src && !M.l_hand)
+	else if(M.r_hand == src)
 		check_hand = BP_L_ARM //item in right hand, check left hand
 	else
 		return FALSE

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -245,7 +245,7 @@ var/list/flooring_types
 				return
 		if(M.stats.getPerk(PERK_SURE_STEP))//You trip even with this perk if klutz or vig below 0
 			return
-		if(prob(50 - our_trippah.stats.getStat(STAT_VIG))) //50 VIG makes you unable to trip
+		if(prob(50 - our_trippah.stats.getStat(STAT_VIG)) && M.slip(null, 6)) //50 VIG makes you unable to trip
 			to_chat(our_trippah, SPAN_WARNING("You gently slam into the plating!"))
 			our_trippah.adjustBruteLoss(5)
 			our_trippah.trip(src, 6)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -81,6 +81,10 @@
 	var/obj/item/I = get_active_hand()
 	unEquip(I, Target, MOVED_DROP)
 
+/mob/proc/drop_offhand(var/atom/Target)
+	var/obj/item/I = get_inactive_hand()
+	unEquip(I, Target, MOVED_DROP)
+
 /mob/proc/is_holding(var/obj/item/W)
 	return is_holding_in_active_hand(W) || is_holding_in_inactive_hand(W)
 

--- a/code/modules/mob/inventory/_docs.dm
+++ b/code/modules/mob/inventory/_docs.dm
@@ -187,7 +187,7 @@ Will return zero if the object is not currently equipped to anyone
 */
 
 
-/obj/item/proc/try_uneqip(target, mob/living/user)
+/obj/item/proc/try_transfer(target, mob/living/user)
 /*
 Not directly related to inventory procs
 Used for unequipping things from mob inventory to hands with mouse DragnDrop

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -116,6 +116,10 @@
 	//This approach is future proof and will support people who possibly have >2 hands
 	var/obj/item/prev_held = get_active_hand()
 
+	if(prev_held)
+		if(prev_held.wielded)
+			prev_held.unwield(src)
+
 	//Now we do the hand swapping
 	src.hand = !( src.hand )
 	for (var/obj/screen/inventory/hand/H in src.HUDinventory)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -185,7 +185,7 @@ This saves us from having to call add_fingerprint() any time something is put in
 		if(slot_r_hand)
 			return BP_R_ARM
 
-/mob/living/carbon/human/equip_to_slot(obj/item/W, slot, redraw_mob = 1)
+/mob/living/carbon/human/equip_to_slot(obj/item/W, slot, redraw_mob = 1, domove = TRUE)
 	LEGACY_SEND_SIGNAL(src, COMSING_HUMAN_EQUITP, W)
 	switch(slot)
 		if(slot_in_backpack)
@@ -200,7 +200,8 @@ This saves us from having to call add_fingerprint() any time something is put in
 		else
 			legacy_equip_to_slot(W, slot, redraw_mob)
 
-			W.forceMove(src)
+			if(domove)
+				W.forceMove(src)
 			W.equipped(src, slot)
 			W.update_wear_icon(redraw_mob)
 			W.screen_loc = find_inv_position(slot)
@@ -296,11 +297,15 @@ This saves us from having to call add_fingerprint() any time something is put in
 			src.r_store = W
 		if(slot_s_store)
 			src.s_store = W
+		if(slot_accessory_buffer)
+			if(src.wear_suit)
+				src.wear_suit.attackby(W, src)
+			return FALSE
 		else
 			to_chat(src, SPAN_DANGER("You are trying to equip this item to an unsupported inventory slot. If possible, please write a ticket with steps to reproduce. Slot was: [slot]"))
 			return
 
-	return 1
+	return TRUE
 
 //Checks if a given slot can be accessed at this time, either to equip or unequip I
 /mob/living/carbon/human/slot_is_accessible(var/slot, var/obj/item/I, mob/user=null)

--- a/code/modules/projectiles/dynamic_cursor.dm
+++ b/code/modules/projectiles/dynamic_cursor.dm
@@ -20,7 +20,7 @@
 	if(!is_held())
 		user.remove_cursor()
 
-/obj/item/gun/try_uneqip(target, mob/living/user)
+/obj/item/gun/try_transfer(target, mob/living/user)
 	. = ..()
 	user.remove_cursor()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Ports a few of the QOL edits in the 'Fixes 2 Codebase Sins' PR Eris has along with porting Eris' wielding system making you drop the item in your other hand; allowing for QUICK emergency wielding.
	
<hr>
</details>

## Changelog
:cl:
fixes: No longer can slip on floors while wearing no-slips.
tweaks: Equip stuff; lets see if it improves any issues.
adds: Wielding an item drops the item in the other hand if you are carrying anything.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
