### PR TITLE
General fixes

### DIFF
--- a/code/game/objects/items/weapons/storage/hardcases.dm
+++ b/code/game/objects/items/weapons/storage/hardcases.dm
@@ -185,6 +185,7 @@ obj/item/storage/hcases/attackby(obj/item/W, mob/user)
 	new /obj/item/device/lighting/toggleable/flashlight/seclite(src)
 	new /obj/item/clothing/accessory/badge/holo/inspector(src)
 	new /obj/item/cell/small/high(src)
+	new /obj/item/cell/medium/high(src)
 
 /obj/item/storage/hcases/ammo/ih/marshal_officer
 	exspand_when_spawned = FALSE //No exspanding cheats

--- a/code/game/objects/random/guns.dm
+++ b/code/game/objects/random/guns.dm
@@ -257,8 +257,8 @@
 	return pickweight(list(
 				/obj/item/gun/energy/xray = 2,
 				/obj/item/gun/energy/sniperrifle = 2,
-				/obj/item/gun/energy/laser/railgun/railrifle = 1,
-				/obj/item/gun/energy/laser/railgun/pistol = 1,
+				// /obj/item/gun/energy/laser/railgun/railrifle = 1, //Needs balancing
+				// /obj/item/gun/energy/laser/railgun/pistol = 1, //Needs balancing
 				/obj/item/gun/energy/plasma/auretian = 1,
 				/obj/item/gun/energy/centurio = 2,
 				/obj/item/gun/energy/gun/nuclear = 2,

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -317,6 +317,17 @@ GLOBAL_LIST_INIT(chameleon_key_to_path, list(
 	icon_state = "bluetie"
 	item_state = "bluetie"
 	chameleon_type = "accessory"
+	
+/obj/item/gun/energy/chameleon
+	name = "\"Liberty\" pistol"
+	desc = "A hologram projector in the shape of a gun. There is a dial on the side to change the gun's disguise."
+	icon = 'icons/obj/guns/projectile/liberty.dmi'
+	icon_state = "liberty"
+	chameleon_type = "gun"
+	fire_sound = 'sound/weapons/Gunshot.ogg'
+	projectile_type = /obj/item/projectile/chameleon
+	charge_meter = FALSE
+	charge_cost = 20
 
 
 /obj/item/gun/energy/chameleon/disguise(newtype, mob/user)


### PR DESCRIPTION
Add: Watch now starts with a medium cell in their hardcase for use with their counselor stun pistol.
Fix: Chameleon guns have had their functionality restored.
Removed: Reductor and a debug railpistol have been removed from dungeon loot pools as they require balancing.