### PR TITLE
Take 2: QOL and Eris Wielding port

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -245,7 +245,7 @@ var/list/flooring_types
 				return
 		if(M.stats.getPerk(PERK_SURE_STEP))//You trip even with this perk if klutz or vig below 0
 			return
-		if(prob(50 - our_trippah.stats.getStat(STAT_VIG))) //50 VIG makes you unable to trip
+		if(prob(50 - our_trippah.stats.getStat(STAT_VIG)) && M.slip(null, 6)) //50 VIG makes you unable to trip
 			to_chat(our_trippah, SPAN_WARNING("You gently slam into the plating!"))
 			our_trippah.adjustBruteLoss(5)
 			our_trippah.trip(src, 6)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -153,17 +153,18 @@
 	return drop_from_inventory(I,Target)
 
 //Attemps to remove an object on a mob.
-/mob/proc/remove_from_mob(var/obj/O)
+/mob/proc/remove_from_mob(var/obj/O, drop = TRUE)
 	src.u_equip(O)
 	if (src.client)
 		src.client.screen -= O
 	O.layer = initial(O.layer)
 	O.set_plane(initial(O.plane))
 	O.screen_loc = null
-	if(istype(O, /obj/item))
+	if(isitem(O))
 		var/obj/item/I = O
-		I.forceMove(src.loc, MOVED_DROP)
 		I.dropped(src)
+		if(drop && !QDELING(O))
+			I.forceMove(get_turf(src), MOVED_DROP)
 	return TRUE
 
 //This function is an unsafe proc used to prepare an item for being moved to a slot, or from a mob to a container


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	About The Pull Request
</summary>
<hr>

Ports a variety of Eris QOL PRs. Guns shouldn't fire when you drop or holster them as if they were still in your hand, wielding an object in your hand while holding another makes you drop the non-wielded item instantly; allowing quick wielding. And no-slips stop from you form.. well - slipping on undertile.
	
<hr>
</details>

## Changelog
:cl:
fixes: No more holstering/dropping a gun but shooting an invisible gun in your hand.
adds: Wielding now makes you drop any item in the opposite hand.
tweak: No-slips now.. act like no-slips. You can't slip on undertile wearing them anymore. (Did you know 50 vig stops you from tripping too???? Quirky.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
