### PR TITLE
Custodian Bug-Fixing 2: The Crisis at San Diego

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -86,8 +86,6 @@
 	)
 
 	perks = list(PERK_STALKER, PERK_ARTIST, PERK_CHANNELING)
-
-	perks = list(PERK_MARKET_PROF, PERK_ARTIST, PERK_STALKER)
 	software_on_spawn = list(
 							 /datum/computer_file/program/scanner,
 							 /datum/computer_file/program/wordprocessor,

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -149,6 +149,7 @@
 	armor_penetration = ARMOR_PEN_MASSIVE
 	w_class = ITEM_SIZE_BULKY
 	price_tag = 800
+	attack_verb = list("attacked", "smashed", "bludgeoned", "beaten")
 	matter = list(MATERIAL_BIO_SILK = 15, MATERIAL_PLASTIC = 10, MATERIAL_PLASTEEL = 16, MATERIAL_STEEL = 30, MATERIAL_SILVER = 2)
 	tool_qualities = list(QUALITY_HAMMERING = 10) //Not designed for that fine nailing
 	var/glowing = FALSE

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -156,6 +156,7 @@
 	embed_mult = 0
 	has_alt_mode = FALSE
 	var/effect_time = 5 MINUTES
+	hitsound = 'sound/weapons/blunthit.ogg'
 
 /obj/item/tool/sword/custodian/warhammer/attack_self(mob/user)
 	var/mob/living/carbon/human/theuser = user
@@ -174,7 +175,7 @@
 
 /obj/item/tool/sword/custodian/warhammer/proc/heat_hammer()
 	set_light(l_range = 4, l_power = 2, l_color = COLOR_YELLOW)
-	visible_message("The [src] radiates a searing heat!")
+	visible_message("[src] radiates a searing heat!")
 	glowing = TRUE
 	heat = 1873
 	update_icon()
@@ -188,7 +189,7 @@
 	damtype = initial(damtype)
 	heat = initial(heat)
 	update_icon()
-	visible_message("The [src]'s heat dies down.")
+	visible_message("[src]'s heat dies down.")
 
 /obj/item/tool/sword/custodian/warhammer/update_icon()
 	if(glowing)

--- a/code/game/objects/items/weapons/tools/misc.dm
+++ b/code/game/objects/items/weapons/tools/misc.dm
@@ -267,7 +267,7 @@
 /obj/item/tool/factorial_omni/Process()
 	..()
 	if(loc != holder) // We're no longer in the owner's hand.
-		visible_message("The [src.name] fades into nothingness.")
+		visible_message("[src.name] fades into nothingness.")
 		STOP_PROCESSING(SSobj, src)
 		qdel(src)
 		return

--- a/code/game/objects/structures/custodian_decorations.dm
+++ b/code/game/objects/structures/custodian_decorations.dm
@@ -39,6 +39,7 @@
 	icon = 'icons/obj/structures/custodian_decorations.dmi'
 	icon_state = "decor_gazer"
 	anchored = TRUE
+	layer = ABOVE_MOB_LAYER
 
 /obj/structure/decor_inloved_1
 	name = "the inloved"
@@ -47,6 +48,7 @@
 	icon_state = "decor_the_inloved"
 	density = TRUE
 	anchored = TRUE
+	layer = ABOVE_MOB_LAYER
 
 /obj/structure/decor_inloved_2
 	name = "the inloved"
@@ -55,6 +57,7 @@
 	icon_state = "decor_the_inloved2"
 	density = TRUE
 	anchored = TRUE
+	layer = ABOVE_MOB_LAYER
 
 /obj/structure/decor_headless_1
 	name = "the headless"
@@ -63,6 +66,7 @@
 	icon_state = "decor_the_headless"
 	density = TRUE
 	anchored = TRUE
+	layer = ABOVE_MOB_LAYER
 
 /obj/structure/decor_headless_2
 	name = "the headless"
@@ -71,6 +75,7 @@
 	icon_state = "decor_the_headless2"
 	density = TRUE
 	anchored = TRUE
+	layer = ABOVE_MOB_LAYER
 
 /obj/structure/decor_headless_3
 	name = "the headless"
@@ -79,6 +84,7 @@
 	icon_state = "decor_the_headless3"
 	density = TRUE
 	anchored = TRUE
+	layer = ABOVE_MOB_LAYER
 
 /obj/structure/decor_the_twins
 	name = "the twins"
@@ -87,6 +93,7 @@
 	icon_state = "decor_the_twins"
 	density = TRUE
 	anchored = TRUE
+	layer = ABOVE_MOB_LAYER
 
 /obj/structure/decor_the_purifier
 	name = "the purifier"
@@ -95,6 +102,7 @@
 	icon_state = "decor_the_purifier"
 	density = TRUE
 	anchored = TRUE
+	layer = ABOVE_MOB_LAYER
 
 /obj/structure/decor_light
 	name = "decor light base item"

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -154,7 +154,7 @@ var/global/obj/machinery/power/eotp/eotp
 					H.adjustOxyLoss(-50)
 					H.adjustBruteLoss(-15)
 					H.adjustFireLoss(-15)
-					to_chat(H, SPAN_NOTICE("You feel a wave of calm pass over you. Your cruciform does a quick routine maintenance, patching any potential minor wounds across your body."))
+					to_chat(H, SPAN_NOTICE("You feel a wave of calm pass over you. Your Hearthcore does a quick routine maintenance, patching any potential minor wounds across your body."))
 
 		else
 			for(var/mob/living/carbon/human/H in disciples)
@@ -186,7 +186,7 @@ var/global/obj/machinery/power/eotp/eotp
 		var/random_stat = pick(ALL_STATS_LEVEL)
 		for(var/mob/living/carbon/human/H in disciples)
 			if(H.stats)
-				to_chat(H, SPAN_NOTICE("You feel the blessing of the church upon you. You are enlightened, and gain deeper knowledge in [random_stat]; however, you can already feel this new-found knowledge is temporary."))
+				to_chat(H, SPAN_NOTICE("You feel enlightened, and gain deeper knowledge in [random_stat]; however, you can already feel this new-found knowledge is temporary."))
 				H.stats.addTempStat(random_stat, stat_buff_power, 20 MINUTES, "Eye_of_the_Protector")
 /*
 	else if(type_release == MATERIAL_REWARD)
@@ -201,7 +201,7 @@ var/global/obj/machinery/power/eotp/eotp
 		for(var/mob/living/carbon/human/H in disciples)
 			var/obj/item/implant/core_implant/cruciform/C = H.get_core_implant(/obj/item/implant/core_implant/cruciform)
 			C.power_regen += initial(C.power_regen)
-			to_chat(H, SPAN_NOTICE("Your cruciform vibrates, its power regeneration enhancing temporarily."))
+			to_chat(H, SPAN_NOTICE("Your Hearthcore vibrates, its power regeneration enhancing temporarily."))
 
 	//for(var/disciple in disciples)
 	//	to_chat(disciple, SPAN_NOTICE("A miracle has occured at the [src]! May the Angels live forever!"))

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -36,6 +36,8 @@ datum/ritual/cruciform/base/thumbspire
 	icon_state = "thumbspire"
 	var/burntime = 120
 	w_class = ITEM_SIZE_HUGE
+	force = 1
+	damtype = BURN
 	slot_flags = null
 	attack_verb = list("burnt", "singed")
 	lit = 1
@@ -57,7 +59,7 @@ datum/ritual/cruciform/base/thumbspire
 		burn_out()
 		return
 	if(loc != holder) // We're no longer in the lecturer's hand, delete self
-		visible_message("The [src.name] flickers away as the fire fades into nothingness")
+		visible_message("[src.name] flickers away as the fire fades into nothingness")
 		STOP_PROCESSING(SSobj, src)
 		qdel(src)
 		return

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -46,6 +46,7 @@ datum/ritual/cruciform/oathbound/fireball
 	max_upgrades = 0
 	slot_flags = null
 	w_class = ITEM_SIZE_HUGE
+	damtype = BURN
 	var/projectile_type = /obj/item/projectile/custodian_fireball // What does it shoot
 	var/use_amount = 1 // How many times can it be used
 	var/mob/living/carbon/holder // Used to delete when dropped
@@ -67,7 +68,7 @@ datum/ritual/cruciform/oathbound/fireball
 
 /obj/item/gun/custodian_fireball/Process()
 	if(loc != holder || (use_amount <= 0)) // We're no longer in the lecturer's hand or we're out of charges.
-		visible_message("The [src] fades into nothingness.")
+		visible_message("[src] fades into nothingness.")
 		STOP_PROCESSING(SSobj, src)
 		qdel(src)
 		return
@@ -619,7 +620,7 @@ datum/ritual/cruciform/oathbound/fireball_big
 
 /datum/ritual/cruciform/forgemaster/tools_of_bonfire/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)
 	var/obj/item/tool/factorial_omni/tool = new /obj/item/tool/factorial_omni(src, user) //create the omni-tool
-	usr.put_in_active_hand(tool) //put it in the active hand
+	usr.put_in_hands(tool) //put it in the active hand
 	set_personal_cooldown(user)
 	return TRUE //refer to code\game\objects\items\weapons\tools\misc.dm for factorial_omni
 

--- a/code/modules/core_implant/cruciform/upgrades.dm
+++ b/code/modules/core_implant/cruciform/upgrades.dm
@@ -14,13 +14,13 @@
 	cruciform = _cruciform
 	active = TRUE
 	OnInstall(target, _cruciform)
-	wearer.visible_message(SPAN_WARNING("[src] attaches itself to [wearer]'s cruciform."))
+	wearer.visible_message(SPAN_WARNING("[src] attaches itself to [wearer]'s Hearthcore."))
 	return active
 
 /obj/item/cruciform_upgrade/proc/uninstall()
 	forceMove(get_turf(wearer))
 	cruciform.upgrade = null
-	wearer.visible_message(SPAN_WARNING("[src] removes itself from [wearer]'s cruciform."))
+	wearer.visible_message(SPAN_WARNING("[src] removes itself from [wearer]'s Hearthcore."))
 	OnUninstall()
 	wearer = null
 	cruciform = null

--- a/maps/__Liberty/map/_Liberty_Colony.dmm
+++ b/maps/__Liberty/map/_Liberty_Colony.dmm
@@ -11121,7 +11121,6 @@
 /area/liberty/engineering/engine_room)
 "cSK" = (
 /obj/structure/damocles_pedestal,
-/obj/item/tool/sword/custodians_damocles,
 /turf/simulated/floor/carpet/bcarpet,
 /area/liberty/command/prime)
 "cSP" = (

--- a/nano/templates/bioreactor.tmpl
+++ b/nano/templates/bioreactor.tmpl
@@ -31,12 +31,12 @@
 		</div>
 	{{/if}}
 
-Biomatter tank:
+Scorch tank:
 
 <hr> </hr>
 
 <div class="itemLabel">
-	Biomatter:
+	Scorch:
 </div>
 	<div class="itemContent">
 		{{:helper.displayBar(data.biotank_occupancy, 0, data.biotank_max_capacity, 'highlight', showText = data.biotank_occupancy + '/' + data.biotank_max_capacity)}}
@@ -48,13 +48,13 @@ Biomatter tank:
 </div>
 	<div class="itemContent">
 		{{if data.biotank_status}}
-			disconnected from bioreactor
+			disconnected from Bonfire
 		{{else}}
-			connected to bioreactor
+			connected to Bonfire
 		{{/if}}
 	</div>
 
-	
+
 <div class="itemLabel">
 	Canister:
 </div>


### PR DESCRIPTION
Fixes some erroneous strings still talking about biomatter and/or Cruciforms.

Sets the statue layers to their correct setting, acting more like trees.

Removes the duplicate perklist for Forgemasters, causing an overwrite.

Set the Forging Touch to be placed into any hand, prioritizing the active hand, rather than canceling if the active hand is occupied.

