### PR TITLE
Enables mask generation on frozen crash site

### DIFF
--- a/maps/_DeepForest/deepforest.dm
+++ b/maps/_DeepForest/deepforest.dm
@@ -25,6 +25,7 @@
 	is_sealed = TRUE
 	height = 2
 	digsites = "TEMPLE"
+	generate_asteroid = TRUE
 
 /obj/map_data/nadezda_f
 	name = "Deep Forest"


### PR DESCRIPTION
!! WARNING !!

This turns generate_asteroid to TRUE on the frozen crash site map data so the unsimulated mask objects placed there are able to generate ore, due to this, initialization takes a bit longer. It's up to the staff to decide if they want this extra initialization time so ores can generate in the frozen crash site, or if the mask objects should be removed, but currently, they show up as unsimulated mask tiles on the live server for anyone to stumble on. So that's bad.