### PR TITLE
Cloning implant adjustments

### DIFF
--- a/code/game/objects/items/weapons/implant/implant.dm
+++ b/code/game/objects/items/weapons/implant/implant.dm
@@ -161,3 +161,10 @@
 		else
 			return TRUE
 	return TRUE
+
+/obj/item/implant/proc/clean_of_hearthcore()
+	if(locate(/obj/item/implant/core_implant/cruciform) in wearer.contents)
+		return FALSE
+	else
+		return TRUE
+

--- a/code/modules/conciousness_backup/base_implant.dm
+++ b/code/modules/conciousness_backup/base_implant.dm
@@ -90,12 +90,23 @@ This should be identical to NEV's Soulcrypt; credit to them for this code.
 		return 1
 
 /obj/item/implant/conback/on_install()
-	if(clean_of_death_alarms())
-		activate()
-		wearer.conciousness_pres = src
-	else
-		to_chat(wearer, SPAN_NOTICE("[src]'s buzzes stating ''ERROR, DEATH ALARM OR OTHER OS DETECTED.''"))
+	if(is_dead(wearer))
+		for(var/mob/O in hearers(3, wearer))
+			O.show_message("\icon[src] <span class = 'notice'>ERROR, NO LIVE CONSCIOUSNESS DETECTED.</span>", 2)
+		return
 
+	if(!clean_of_death_alarms())
+		for(var/mob/O in hearers(3, wearer))
+			O.show_message("\icon[src] <span class = 'notice'>ERROR, DEATH ALARM OR OTHER OS DETECTED.</span>", 2)
+		return
+
+	if(!clean_of_hearthcore())
+		for(var/mob/O in hearers(3, wearer))
+			O.show_message("\icon[src] <span class = 'notice'>ERROR, INTERFERING HARDWARE DETECTED.</span>", 2)
+		return
+
+	activate()
+	wearer.conciousness_pres = src
 
 /obj/item/implant/conback/on_uninstall()
 	. = ..()


### PR DESCRIPTION
Installing a Consciousness Backup implant on Hearthcore users, death alarm users, and dead users now fails the activation and outputs an audible message in a close radius to notify the error.