### PR TITLE
Fixes rogue drones, adjusts end event for vox and ameridian events

### DIFF
--- a/code/game/gamemodes/events/migration_ameridian.dm
+++ b/code/game/gamemodes/events/migration_ameridian.dm
@@ -63,11 +63,12 @@
 
 /datum/event/ameridian_migration/end()
 	for(var/obj/structure/ameridian_crystal/a in spawned_ameridian)
-		if(!a.stat)
-			var/turf/T = get_turf(a)
-			if(istype(T, /turf/space)) //If they end up outside the map then we remove them on end
-				spawned_ameridian.Remove(a)
-				qdel(a)
-			if(istype(T, /turf/unsimulated/wall/jungle))
-				spawned_ameridian.Remove(a)
-				qdel(a)
+		if(prob(85)) //20% chance to stay
+			if(!a.stat)
+				var/turf/T = get_turf(a)
+				if(istype(T, /turf/space)) //If they end up outside the map then we remove them on end
+					spawned_ameridian.Remove(a)
+					qdel(a)
+				if(istype(T, /turf/unsimulated/wall/jungle))
+					spawned_ameridian.Remove(a)
+					qdel(a)

--- a/code/game/gamemodes/events/migration_vox.dm
+++ b/code/game/gamemodes/events/migration_vox.dm
@@ -63,11 +63,12 @@
 
 /datum/event/vox_migration/end()
 	for(var/mob/living/carbon/superior_animal/vox/v in spawned_vox)
-		if(!v.stat)
-			var/turf/T = get_turf(v)
-			if(istype(T, /turf/space)) //If they end up outside the map then we remove them on end
-				spawned_vox.Remove(v)
-				qdel(v)
-			if(istype(T, /turf/unsimulated/wall/jungle))
-				spawned_vox.Remove(v)
-				qdel(v)
+		if(prob(85)) //20% chance to stay
+			if(!v.stat)
+				var/turf/T = get_turf(v)
+				if(istype(T, /turf/space)) //If they end up outside the map then we remove them on end
+					spawned_vox.Remove(v)
+					qdel(v)
+				if(istype(T, /turf/unsimulated/wall/jungle))
+					spawned_vox.Remove(v)
+					qdel(v)

--- a/code/game/gamemodes/events/rogue_drones.dm
+++ b/code/game/gamemodes/events/rogue_drones.dm
@@ -36,7 +36,7 @@
 
 		//The number of windows near each tile is recorded
 		var/numwin
-		for (var/turf/simulated/floor/asteroid/grass/W in view(4, T))
+		for (var/turf/simulated/floor/snow/W in view(4, T))
 			numwin++
 
 		//And the square of it is entered into the list as a weight


### PR DESCRIPTION
Fixes the rogue drone event, as I missed it when fixing the Ameridian and Vox spawning events.

Both the Ameridian and Vox spawning events now leave behind 15% of the spawned mobs when ending instead of deleting them all.