### PR TITLE
Gun and sprite fix

### DIFF
--- a/code/modules/economy/coalition_dinar.dm
+++ b/code/modules/economy/coalition_dinar.dm
@@ -28,7 +28,7 @@
 		if(1000 to 4999)
 			icon_state = "[initial(icon_state)]1000"
 		if(5000 to 10001)
-			icon_state = "[initial(icon_state)]5000"
+			icon_state = "[initial(icon_state)]10000"
 
 	..()
 

--- a/code/modules/projectiles/guns/projectile/revolver/ranger.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/ranger.dm
@@ -33,8 +33,8 @@
 	gun_parts = list(/obj/item/part/gun/frame/ranger = 1, /obj/item/part/gun/grip/black = 1, /obj/item/part/gun/mechanism/revolver = 1, /obj/item/part/gun/barrel/magnum = 1)
 
 /obj/item/part/gun/frame/ranger
-	name = "Minotaur frame"
-	desc = "A Minotaur revolver frame. For a true frontier ranger."
+	name = "Ranger frame"
+	desc = "A Ranger revolver frame. For a true frontier ranger."
 	icon_state = "frame_revolver"
 	result = /obj/item/gun/projectile/revolver/ranger
 	resultvars = list(/obj/item/gun/projectile/revolver/ranger)


### PR DESCRIPTION
Fix: Ranger revolver frame renamed from Minotaur to Ranger.
Fix: Large stacks of dinars no longer vanish.