### PR TITLE
Moving crafting recipes from Union to PIRS, giving Union cheaper alternatives of some recipes, and generally QOLing some of their stuff

### DIFF
--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -1,3 +1,4 @@
+//PIRS/TFIRMA SPLIT HAS REMOVED LOTS OF STUFF
 /datum/craft_recipe/terra
 	category = "Terra-Therma"
 	time = 100
@@ -18,112 +19,31 @@
 		list(QUALITY_SAWING, 30, "time" = 5)
 	)
 
-//bullets -----------------------------
-
-/datum/craft_recipe/terra/payload_arrow
-	name = "bulk empty payload arrow"
-	result = /obj/item/ammo_casing/arrow/empty_payload/bulk
-	icon_state = "woodworking"
-	steps = list(
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 1),
-		list(QUALITY_WELDING, 40, "time" = 5),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 1),
-		list(QUALITY_CUTTING, 40, "time" = 5)
-	)
-
-//Armor mods ----------------------
-/datum/craft_recipe/terra/melee
-	name = "melee plating"
-	result = /obj/item/tool_upgrade/armor/melee
-	icon_state = "clothing"
-	steps = list(
-		list(CRAFT_MATERIAL, 30, MATERIAL_STEEL, "time" = 60),
-		list(QUALITY_WELDING, 40, "time" = 60),
-		list(QUALITY_CUTTING, 30, "time" = 180),
-		list(QUALITY_HAMMERING, 30, "time" = 180),
-		list(QUALITY_SCREW_DRIVING, 40, "time" = 90),
-		list(/obj/item/tool_upgrade/reinforcement/rubbermesh, 1),
-		list(QUALITY_BOLT_TURNING, 40, "time" = 120),
-		list(QUALITY_SAWING, 30, "time" = 60)
-	)
-
-/datum/craft_recipe/terra/bullet
-	name = "ballistic plating"
-	result = /obj/item/tool_upgrade/armor/bullet
-	icon_state = "clothing"
-	steps = list(
-		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 20),
-		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTIC , "time" = 20),
-		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 20),
-		list(QUALITY_WELDING, 40, "time" = 60),
-		list(QUALITY_CUTTING, 30, "time" = 180),
-		list(QUALITY_HAMMERING, 30, "time" = 180),
-		list(/obj/item/tool_upgrade/reinforcement/rubbermesh, 1),
-		list(QUALITY_SCREW_DRIVING, 40, "time" = 90),
-		list(QUALITY_BOLT_TURNING, 40, "time" = 120),
-		list(QUALITY_SAWING, 30, "time" = 60)
-	)
-
-/datum/craft_recipe/terra/energy
-	name = "energy plating"
-	result = /obj/item/tool_upgrade/armor/energy
-	icon_state = "clothing"
-	steps = list(
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLATINUM, "time" = 30),
-		list(CRAFT_MATERIAL, 12, MATERIAL_PLASTIC , "time" = 30),
-		list(QUALITY_WELDING, 40, "time" = 60),
-		list(QUALITY_CUTTING, 30, "time" = 180),
-		list(QUALITY_HAMMERING, 30, "time" = 180),
-		list(QUALITY_SCREW_DRIVING, 40, "time" = 90),
-		list(/obj/item/tool_upgrade/reinforcement/rubbermesh, 1),
-		list(QUALITY_BOLT_TURNING, 40, "time" = 120),
-		list(QUALITY_SAWING, 30, "time" = 60)
-	)
-
-/datum/craft_recipe/terra/bomb
-	name = "bomb proofing"
-	result = /obj/item/tool_upgrade/armor/bomb
-	icon_state = "clothing"
-	steps = list(
-		list(CRAFT_MATERIAL, 20, MATERIAL_PLASTEEL, "time" = 60),
-		list(CRAFT_MATERIAL, 20, MATERIAL_STEEL, "time" = 60),
-		list(QUALITY_WELDING, 40, "time" = 60),
-		list(QUALITY_CUTTING, 30, "time" = 180),
-		list(QUALITY_HAMMERING, 30, "time" = 180),
-		list(QUALITY_SCREW_DRIVING, 40, "time" = 90),
-		list(/obj/item/tool_upgrade/reinforcement/rubbermesh, 1),
-		list(QUALITY_BOLT_TURNING, 40, "time" = 120),
-		list(QUALITY_SAWING, 30, "time" = 60)
-	)
-
-//Robot Armor ----------------------
-
-/datum/craft_recipe/terra/robotmelee //Lots of steps
-	name = "robot mark v armor plating"
-	result = /obj/item/robot_parts/robot_component/armour/mkv
-	steps = list(
-		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 90),
-		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 30),
-		list(QUALITY_WELDING, 40, "time" = 90),
-		list(QUALITY_CUTTING, 30, "time" = 180),
-		list(QUALITY_HAMMERING, 30, "time" = 180),
-		list(QUALITY_SCREW_DRIVING, 40, "time" = 90),
-		list(QUALITY_BOLT_TURNING, 40, "time" = 120),
-		list(QUALITY_SAWING, 30, "time" = 60)
-	)
-
 //Tools --------------------------
 /datum/craft_recipe/terra/arcwelder
 	name = "arc welder"
 	result = /obj/item/tool/baton/arcwelder
 	steps = list(
-		list(CRAFT_MATERIAL, 4, MATERIAL_PLASTEEL, "time" = 60),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL, "time" = 60),
 		list(QUALITY_CUTTING, 20, "time" = 40),
-		list(QUALITY_HAMMERING, 30, "time" = 40),
+		list(QUALITY_HAMMERING, 25, "time" = 40),
 		list(/obj/item/stack/cable_coil, 5, "time" = 20),
 		list(QUALITY_WIRE_CUTTING, 20, 30),
 		list(QUALITY_SCREW_DRIVING, 20, "time" = 60),
-		list(QUALITY_BOLT_TURNING, 30, "time" = 40)
+		list(QUALITY_BOLT_TURNING, 25, "time" = 40)
+	)
+
+/datum/craft_recipe/terra/omnitool
+	name = "Munchkin 5000"
+	result = /obj/item/tool/omnitool
+	steps = list(
+		list(CRAFT_MATERIAL, 4, MATERIAL_PLASTEEL, "time" = 60),
+		list(QUALITY_CUTTING, 20, "time" = 40),
+		list(QUALITY_HAMMERING, 25, "time" = 40),
+		list(/obj/item/stack/cable_coil, 15, "time" = 20),
+		list(QUALITY_WIRE_CUTTING, 20, 30),
+		list(QUALITY_SCREW_DRIVING, 20, "time" = 60),
+		list(QUALITY_BOLT_TURNING, 25, "time" = 40)
 	)
 
 /datum/craft_recipe/terra/polytool
@@ -188,7 +108,6 @@
 	name = "\"Little Helper\" Omnitool"
 	result = /obj/item/tool/engimultitool
 	steps = list(
-		list (/obj/item/organ_module/active/simple/makeshift, 1),
 		list (QUALITY_SCREW_DRIVING, 20, 40),
 		list (QUALITY_WIRE_CUTTING, 20, 40),
 		list (CRAFT_MATERIAL, 1, MATERIAL_OSMIUM, 60),
@@ -198,9 +117,9 @@
 		list (QUALITY_HAMMERING, 30, 20),
 		list (/obj/item/stack/cable_coil, 30, 20),
 		list (QUALITY_WIRE_CUTTING, 20, 40),
-		list (/obj/item/stock_parts/capacitor/handmade, 1, 40),
+		list (/obj/item/stock_parts/capacitor/super, 1, 40),
 		list (QUALITY_PULSING, 30, 20),
-		list (/obj/item/stock_parts/manipulator/handmade, 1, 30),
+		list (/obj/item/stock_parts/manipulator/pico, 1, 30),
 		list (QUALITY_SCREW_DRIVING, 30)
 	)
 
@@ -224,7 +143,7 @@
 		list(QUALITY_SCREW_DRIVING, 40, "time" = 20),
 	)
 
-/datum/craft_recipe/terra/nanoshotgun
+/datum/craft_recipe/terra/nanoshotgun //kinda bad
 	name = "MKII Forger compressed-matter shotgun"
 	result = /obj/item/gun/projectile/matter_gun/shotgun
 	steps = list(
@@ -238,8 +157,8 @@
 		list(QUALITY_SCREW_DRIVING, 40, "time" = 20),
 		list(/obj/item/stack/cable_coil, 20, "time" = 15),
 		list(QUALITY_WIRE_CUTTING, 40, "time" = 15),
-		list(/obj/item/stock_parts/capacitor/handmade, 1, "time" = 10),
-		list(/obj/item/stock_parts/micro_laser/handmade, 1, "time" = 10),
+		list(/obj/item/stock_parts/capacitor/adv, 1, "time" = 10),
+		list(/obj/item/stock_parts/micro_laser/high, 1, "time" = 10),
 		list(QUALITY_SCREW_DRIVING, 40, "time" = 20),
 	)
 
@@ -351,14 +270,14 @@
 
 //Wearables =========================
 /datum/craft_recipe/terra/nv_guild
-	name = "Optimized NV Goggles"
+	name = "Optimized NV-MESON Goggles"
 	result = /obj/item/clothing/glasses/powered/night/guild/crafted
 	icon_state = "clothing"
 	steps = list(
 		list(/obj/item/clothing/glasses/powered/meson, 1, "time" = 30),
-		list(CRAFT_MATERIAL, 2, MATERIAL_RGLASS),
+		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
 		list(QUALITY_WELDING, 40, "time"= 60),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL, "time" = 30),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 30),
 		list(QUALITY_BOLT_TURNING, 40, "time" = 40),
 		list(CRAFT_MATERIAL, 1, MATERIAL_URANIUM, "time" = 20),
 		list(QUALITY_WIRE_CUTTING, 40, 30),
@@ -371,12 +290,12 @@
 	result = /obj/item/clothing/suit/armor/vest/technomancersuit
 	icon_state = "clothing"
 	steps = list(
-		list(CRAFT_MATERIAL, 40, MATERIAL_PLASTEEL, "time" = 60),
+		list(CRAFT_MATERIAL, 20, MATERIAL_PLASTEEL, "time" = 60),
 		list(QUALITY_SAWING, 60, "time" = 60),
 		list(QUALITY_WELDING, 40, "time" = 60),
 		list(QUALITY_CUTTING, 30, "time" = 40),
 		list(QUALITY_HAMMERING, 45, "time" = 40),
-		list(/obj/item/stack/cable_coil, 30, "time" = 20),
+		list(/obj/item/stack/cable_coil, 15, "time" = 20),
 		list(QUALITY_WIRE_CUTTING, 40, 30),
 		list(QUALITY_SCREW_DRIVING, 40, "time" = 60),
 		list(QUALITY_BOLT_TURNING, 40, "time" = 40)
@@ -387,12 +306,12 @@
 	result = /obj/item/clothing/head/helmet/technomancersuit
 	icon_state = "clothing"
 	steps = list(
-		list(CRAFT_MATERIAL, 20, MATERIAL_PLASTEEL, "time" = 60),
+		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 60),
 		list(QUALITY_SAWING, 60, "time" = 60),
 		list(QUALITY_WELDING, 40, "time" = 60),
 		list(QUALITY_CUTTING, 30, "time" = 40),
 		list(QUALITY_HAMMERING, 45, "time" = 40),
-		list(/obj/item/stack/cable_coil, 30, "time" = 20),
+		list(/obj/item/stack/cable_coil, 15, "time" = 20),
 		list(QUALITY_WIRE_CUTTING, 40, 30),
 		list(QUALITY_SCREW_DRIVING, 40, "time" = 60),
 		list(QUALITY_BOLT_TURNING, 40, "time" = 40)
@@ -407,9 +326,9 @@
 		list(/obj/item/clothing/gloves/insulated, 1, "time" = 15),
 		list(/obj/item/stack/cable_coil, 2, "time" = 5),
 		list(QUALITY_CUTTING, 15, 10),
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC), //So if we use buget we have a reason to think its really shock proof
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC), //So if we use buget we have a reason to think its really shock proof
 		list(QUALITY_WELDING, 10, "time" = 40),
-		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL),
+		list(CRAFT_MATERIAL, 1, MATERIAL_STEEL),
 		list(QUALITY_HAMMERING, 15, 10)
 	)
 
@@ -420,8 +339,7 @@
 	steps = list(
 		list(/obj/item/storage/belt, 1, "time" = 30),
 		list(/obj/item/storage/belt, 1, "time" = 30),
-		list(/obj/item/stack/cable_coil, 30, "time" = 30),
-		list(/obj/item/storage/pouch/medium_generic, 1, "time" = 40)
+		list(/obj/item/stack/cable_coil, 30, "time" = 30)
 	)
 
 /datum/craft_recipe/terra/sheet_stacker
@@ -444,7 +362,7 @@
 	name = "Rubber Mesh"
 	result = /obj/item/tool_upgrade/reinforcement/rubbermesh
 	steps = list(
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC, "time" = 30),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC, "time" = 30), //Cheaper
 		list(QUALITY_WIRE_CUTTING, 20, "time" = 90)
 	)
 
@@ -453,137 +371,12 @@
 	name = "Booster"
 	result = /obj/item/tool_upgrade/productivity/booster
 	steps = list(
-		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL, "time" = 30),
+		list(CRAFT_MATERIAL, 2, MATERIAL_STEEL, "time" = 30),
 		list(QUALITY_HAMMERING, 30, "time" = 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC, "time" = 30),
 		list(QUALITY_SCREW_DRIVING, 25, "time" = 90),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD, "time" = 30),
+		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD, "time" = 30),
 		list(QUALITY_BOLT_TURNING, 20, "time" = 40)
-	)
-
-//Gun Mods
-/datum/craft_recipe/terra/weintraub
-	name = "\"Hurricane\" full auto kit"
-	result = /obj/item/gun_upgrade/mechanism/weintraub
-	icon_state = "gun"
-	steps = list(
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
-		list(QUALITY_SCREW_DRIVING, 25, "time" = 90)
-	)
-
-//Gun Mods
-/datum/craft_recipe/terra/tensioner
-	name =  "weighted pulley kit"
-	result = /obj/item/gun_upgrade/mechanism/tensioner
-	steps = list(
-		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(/obj/item/stack/cable_coil, 5, "time" = 30),
-		list(QUALITY_WIRE_CUTTING, 25, "time" = 90)
-	)
-
-//Gun Mods
-/datum/craft_recipe/terra/detensioner
-	name =  "compound pulley kit"
-	result = /obj/item/gun_upgrade/mechanism/detensioner
-	steps = list(
-		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 30),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
-		list(QUALITY_WIRE_CUTTING, 25, "time" = 90)
-	)
-
-/datum/craft_recipe/terra/overshooter
-	name = "\"Overshooter\" internal magazine kit"
-	result = /obj/item/gun_upgrade/mechanism/overshooter
-	icon_state = "gun"
-	steps = list(
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
-		list(QUALITY_SCREW_DRIVING, 25, "time" = 90)
-	)
-
-/datum/craft_recipe/terra/dangerzone
-	name = "\"Danger Zone\" Trigger"
-	result = /obj/item/gun_upgrade/trigger/dangerzone
-	icon_state = "gun"
-	steps = list(
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
-		list(QUALITY_BOLT_TURNING, 25, "time" = 90)
-	)
-
-/datum/craft_recipe/terra/forged
-	name = "Forged Barrel"
-	result = /obj/item/gun_upgrade/barrel/forged
-	icon_state = "gun"
-	steps = list(
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC, "time" = 30),
-		list(QUALITY_BOLT_TURNING, 25, "time" = 90)
-	)
-
-/datum/craft_recipe/terra/heavy_barrel
-	name = "Heavy barrel"
-	result = /obj/item/gun_upgrade/barrel/bore
-	icon_state = "gun"
-	steps = list(
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC, "time" = 30),
-		list(QUALITY_BOLT_TURNING, 25, "time" = 90),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(QUALITY_DRILLING, 60, "time" = 90),
-		list(/obj/item/tool_upgrade/refinement/ported_barrel, 1, "time" = 30),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_BOLT_TURNING, 25, "time" = 90)
-	)
-
-/datum/craft_recipe/terra/silencer
-	name = "Silencer"
-	result = /obj/item/gun_upgrade/muzzle/silencer
-	icon_state = "gun"
-	steps = list(
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
-		list(QUALITY_CUTTING, 25, "time" = 90)
-	)
-
-/datum/craft_recipe/terra/watchman
-	name = "Terra-Therma Union \"Watchman\" scope"
-	result = /obj/item/gun_upgrade/scope/watchman
-	icon_state = "gun"
-	steps = list(
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_SAWING, 30, "time" = 60),
-		list(QUALITY_HAMMERING, 20, "time" = 40),
-		list(QUALITY_WELDING, 40, "time" = 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GLASS, "time" = 30),
-		list(QUALITY_CUTTING, 25, "time" = 90)
 	)
 /*
 //Traps
@@ -617,8 +410,8 @@
 	icon_state = "electronic"
 	steps = list(
 		list(/obj/item/circuitboard/autolathe, 1, "time" = 30),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD),
-		list(CRAFT_MATERIAL, 2, MATERIAL_SILVER),
+		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD),
+		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
 		list(/obj/item/stack/cable_coil, 5, "time" = 20),
 		list(QUALITY_SCREW_DRIVING, 20, "time" = 90),
 		list(QUALITY_WELDING, 30, "time" = 90)
@@ -640,248 +433,7 @@
 		list(QUALITY_HAMMERING, 30, "time" = 40),
 		list(QUALITY_SAWING, 30, "time" = 60),
 		//list(QUALITY_DRILLING, 60, "time" = 90),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(CRAFT_MATERIAL, 2, MATERIAL_SILVER)
-	)
-
-/datum/craft_recipe/terra/safety_clamp
-	name = "Hydraulic clamp overclock: KILL CLAMP"
-	result = /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
-	steps = list(
-		list(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp, 1, "time" = 60),
-		list(QUALITY_BOLT_TURNING, 30, "time" = 40),
-		list(/obj/item/tool_upgrade/productivity/motor, 1, "time" = 60),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(/obj/item/tool_upgrade/augment/hydraulic, 1, "time" = 60),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL),
-		list(QUALITY_WELDING, 30, "time" = 40),
-		list(/obj/item/tool_upgrade/augment/spikes, 1, "time" = 60)
-	)
-
-/datum/craft_recipe/terra/tesla_energy_relay
-	name = "Mech energy relay"
-	result = /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
-	steps = list(
-		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 30),
-		list(QUALITY_WELDING, 45, "time" = 40),
-		list(QUALITY_BOLT_TURNING, 40, 70),
-		list(/obj/item/computer_hardware/tesla_link, 2, "time" = 60),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(/obj/item/stack/cable_coil, 15, "time" = 90),
-		list(QUALITY_WIRE_CUTTING, 25, "time" = 90),
-		list(/obj/item/stock_parts/capacitor/super, 1, "time" = 60),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD)
-	)
-
-/datum/craft_recipe/terra/guild_bin
-	name = "Hand Cast Matter Bin"
-	result = /obj/item/stock_parts/matter_bin/handmade
-	steps = list(
-		list(/obj/item/stock_parts/matter_bin/super, 1),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL), //Quite useless in most cases so were cheaper
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(QUALITY_HAMMERING, 40),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/terra/guild_manip
-	name = "Perfected Forged Manipulator"
-	result = /obj/item/stock_parts/manipulator/handmade
-	steps = list(
-		list(/obj/item/stock_parts/manipulator/pico, 1),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL), //Are main thing were exspensive do to being the main crafted item
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(/obj/item/stack/cable_coil, 10),
-		list(QUALITY_HAMMERING, 40),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/terra/guild_laser
-	name = "Handmade Perfected Micro-Laser"
-	result = /obj/item/stock_parts/micro_laser/handmade
-	steps = list(
-		list(/obj/item/stock_parts/micro_laser/ultra, 1),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
-		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/terra/guild_scanner
-	name = "Manually Perfected Scanning Module"
-	result = /obj/item/stock_parts/scanning_module/handmade
-	steps = list(
-		list(/obj/item/stock_parts/scanning_module/phasic, 1),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
 		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD),
 		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/terra/guild_capacitor
-	name = "Crafted Ultra Capacitor"
-	result = /obj/item/stock_parts/capacitor/handmade
-	steps = list(
-		list(/obj/item/stock_parts/capacitor/super, 1),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/terra/guild_bin_alt
-	name = "Hand Cast Matter Bin Alt"
-	result = /obj/item/stock_parts/matter_bin/handmade
-	steps = list(
-		list(/obj/item/stock_parts/matter_bin/adv, 2),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(QUALITY_HAMMERING, 40),
-		list(QUALITY_SAWING, 60)
-	)
-/*
-/datum/craft_recipe/terra/guild_manip_alt
-	name = "Forged Manipulator Alt"
-	result = /obj/item/stock_parts/manipulator/handmade
-	steps = list(
-		list(/obj/item/stock_parts/manipulator/nano, 2),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL),
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(/obj/item/stack/cable_coil, 10),
-		list(QUALITY_HAMMERING, 40),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/terra/guild_laser_alt
-	name = "Perfected Micro-Laser Alt"
-	result = /obj/item/stock_parts/micro_laser/handmade
-	steps = list(
-		list(/obj/item/stock_parts/micro_laser/high, 2),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
-		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/terra/guild_scanner_alt
-	name = "Perfected Scanning Module Alt"
-	result = /obj/item/stock_parts/scanning_module/handmade
-	steps = list(
-		list(/obj/item/stock_parts/scanning_module/adv, 2),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/terra/guild_capacitor_alt
-	name = "Crafted Ultra Capacitor Alt"
-	result = /obj/item/stock_parts/capacitor/handmade
-	steps = list(
-		list(/obj/item/stock_parts/capacitor/adv, 2),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60)
-	)
-*/
-// Just speeder to make in bulk then one by one, and costs a upfrunt of 1 cardbord they can recoop
-/datum/craft_recipe/terra/guild_bin_box
-	name = "Box of Cast Matter Bins"
-	result = /obj/item/storage/box/guild_bin
-	steps = list(
-		list(/obj/item/stock_parts/matter_bin/super, 4),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(CRAFT_MATERIAL, 4, MATERIAL_PLASTEEL),
-		list(CRAFT_MATERIAL, 4, MATERIAL_PLASMAGLASS),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(QUALITY_HAMMERING, 40),
-		list(QUALITY_SAWING, 60),
-		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
-	)
-
-/datum/craft_recipe/terra/guild_manip_box
-	name = "Box of Forged Manipulators"
-	result = /obj/item/storage/box/guild_manip
-	steps = list(
-		list(/obj/item/stock_parts/manipulator/pico, 4),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 8, MATERIAL_PLASTEEL),
-		list(CRAFT_MATERIAL, 8, MATERIAL_PLASTIC),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(/obj/item/stack/cable_coil, 10),
-		list(QUALITY_HAMMERING, 40),
-		list(QUALITY_SAWING, 60),
-		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
-	)
-
-/datum/craft_recipe/terra/guild_laser_box
-	name = "Box of Perfected Micro-Lasers"
-	result = /obj/item/storage/box/guild_laser
-	steps = list(
-		list(/obj/item/stock_parts/micro_laser/ultra, 4),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 4, MATERIAL_PLASMAGLASS),
-		list(CRAFT_MATERIAL, 4, MATERIAL_RGLASS),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(QUALITY_SAWING, 60),
-		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
-	)
-
-/datum/craft_recipe/terra/guild_scanner_box
-	name = "Box of Perfected Scanning Modules"
-	result = /obj/item/storage/box/guild_scanner
-	steps = list(
-		list(/obj/item/stock_parts/scanning_module/phasic, 4),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 4, MATERIAL_GOLD),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(CRAFT_MATERIAL, 4, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60),
-		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
-	)
-
-/datum/craft_recipe/terra/guild_capacitor_box
-	name = "Box of Crafted Ultra Capacitors"
-	result = /obj/item/storage/box/guild_capacitor
-	steps = list(
-		list(/obj/item/stock_parts/capacitor/super, 4),
-		list(QUALITY_SCREW_DRIVING, 40, 70),
-		list(CRAFT_MATERIAL, 4, MATERIAL_GOLD),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 40),
-		list(CRAFT_MATERIAL, 4, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60),
-		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
+		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER)
 	)

--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -438,3 +438,55 @@
 		list(QUALITY_BOLT_TURNING, 10, 70),
 		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER)
 	)
+
+/datum/craft_recipe/terra/guild_capacitor
+	name = "Crafted Super Capacitor"
+	result = /obj/item/stock_parts/capacitor/super
+	steps = list(
+		list(/obj/item/stock_parts/capacitor, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
+		list(QUALITY_SAWING, 30)
+	)
+
+/datum/craft_recipe/terra/guild_manip
+	name = "Crafted Pico Manipulator"
+	result = /obj/item/stock_parts/manipulator/pico
+	steps = list(
+		list(/obj/item/stock_parts/manipulator, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
+		list(QUALITY_SAWING, 30)
+	)
+
+/datum/craft_recipe/terra/guild_matterbin
+	name = "Crafted Super Matterbin"
+	result = /obj/item/stock_parts/matter_bin/super
+	steps = list(
+		list(/obj/item/stock_parts/matter_bin, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
+		list(QUALITY_SAWING, 30)
+	)
+
+/datum/craft_recipe/terra/guild_laser
+	name = "Crafted Ultra High Power Laser"
+	result = /obj/item/stock_parts/micro_laser/ultra
+	steps = list(
+		list(/obj/item/stock_parts/micro_laser, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
+		list(QUALITY_SAWING, 30)
+	)

--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -254,7 +254,7 @@
 	list(/obj/item/tool_upgrade/augment/fuel_tank, 1, "time" = 30)
 	)
 
-/datum/craft_recipe/terra/bastion
+/datum/craft_recipe/terra/bastion //Terra can craft this without the shield
 	name = "Bastion Shield"
 	result = /obj/item/shield/riot/bastion
 	steps = list(
@@ -262,7 +262,7 @@
 	list(QUALITY_SAWING, 30, "time" = 60),
 	list(CRAFT_MATERIAL, 2, MATERIAL_STEEL, "time" = 30),
 	list(QUALITY_WELDING, 40, "time"= 60),
-	list(/obj/item/shield/riot, 1, "time" = 30),
+	list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 30),
 	list(QUALITY_HAMMERING, 45, "time" = 40),
 	list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS, "time" = 30)
 	)
@@ -339,20 +339,21 @@
 	steps = list(
 		list(/obj/item/storage/belt, 1, "time" = 30),
 		list(/obj/item/storage/belt, 1, "time" = 30),
-		list(/obj/item/stack/cable_coil, 30, "time" = 30)
+		list(/obj/item/stack/cable_coil, 30, "time" = 30),
+		list(/obj/item/storage/pouch/medium_generic, 1, "time" = 40)
 	)
 
-/datum/craft_recipe/terra/sheet_stacker
+/datum/craft_recipe/terra/sheet_stacker //Cheaper than the PIRS recipe.
 	name = "advanced sheet snatcher"
 	icon_state = "woodworking"
 	result = /obj/item/storage/bag/sheetsnatcher/guild
 	steps = list(
-		list(CRAFT_MATERIAL, 10, MATERIAL_WOOD, "time" = 30),
+		list(CRAFT_MATERIAL, 4, MATERIAL_WOOD, "time" = 30),
 		list(QUALITY_SCREW_DRIVING, 40, "time" = 20),
-		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL, "time" = 60),
+		list(CRAFT_MATERIAL, 2, MATERIAL_STEEL, "time" = 60),
 		list(QUALITY_ADHESIVE, 10, "time" = 60),
 		list(/obj/item/stack/cable_coil, 30, "time" = 30),
-		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL, "time" = 30),
 	)
 
 //Tool/Gun Mods ---------------------
@@ -362,7 +363,7 @@
 	name = "Rubber Mesh"
 	result = /obj/item/tool_upgrade/reinforcement/rubbermesh
 	steps = list(
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC, "time" = 30), //Cheaper
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30), //Cheaper
 		list(QUALITY_WIRE_CUTTING, 20, "time" = 90)
 	)
 

--- a/code/datums/craft/recipes/pirs.dm
+++ b/code/datums/craft/recipes/pirs.dm
@@ -1,0 +1,583 @@
+/datum/craft_recipe/pirs
+	category = "PIRS"
+	time = 100
+	related_stats = list(STAT_COG)
+	requiredPerk = PERK_SCIENCE
+
+//Materal Craft ------------------
+//bullets -----------------------------
+
+/datum/craft_recipe/pirs/payload_arrow
+	name = "bulk empty payload arrow"
+	result = /obj/item/ammo_casing/arrow/empty_payload/bulk
+	icon_state = "woodworking"
+	steps = list(
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 1),
+		list(QUALITY_WELDING, 35, "time" = 5),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 1),
+		list(QUALITY_CUTTING, 35, "time" = 5)
+	)
+
+//Armor mods ----------------------
+/datum/craft_recipe/pirs/melee
+	name = "melee plating"
+	result = /obj/item/tool_upgrade/armor/melee
+	icon_state = "clothing"
+	steps = list(
+		list(CRAFT_MATERIAL, 30, MATERIAL_STEEL, "time" = 60),
+		list(QUALITY_WELDING, 35, "time" = 60),
+		list(QUALITY_CUTTING, 30, "time" = 180),
+		list(QUALITY_HAMMERING, 30, "time" = 180),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 90),
+		list(/obj/item/tool_upgrade/reinforcement/rubbermesh, 1),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 120),
+		list(QUALITY_SAWING, 30, "time" = 60)
+	)
+
+/datum/craft_recipe/pirs/bullet
+	name = "ballistic plating"
+	result = /obj/item/tool_upgrade/armor/bullet
+	icon_state = "clothing"
+	steps = list(
+		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 20),
+		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTIC , "time" = 20),
+		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 20),
+		list(QUALITY_WELDING, 35, "time" = 60),
+		list(QUALITY_CUTTING, 30, "time" = 180),
+		list(QUALITY_HAMMERING, 30, "time" = 180),
+		list(/obj/item/tool_upgrade/reinforcement/rubbermesh, 1),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 90),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 120),
+		list(QUALITY_SAWING, 30, "time" = 60)
+	)
+
+/datum/craft_recipe/pirs/energy
+	name = "energy plating"
+	result = /obj/item/tool_upgrade/armor/energy
+	icon_state = "clothing"
+	steps = list(
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLATINUM, "time" = 30),
+		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTIC , "time" = 30),
+		list(QUALITY_WELDING, 35, "time" = 60),
+		list(QUALITY_CUTTING, 30, "time" = 180),
+		list(QUALITY_HAMMERING, 30, "time" = 180),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 90),
+		list(/obj/item/tool_upgrade/reinforcement/rubbermesh, 1),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 120),
+		list(QUALITY_SAWING, 30, "time" = 60)
+	)
+
+/datum/craft_recipe/pirs/bomb
+	name = "bomb proofing"
+	result = /obj/item/tool_upgrade/armor/bomb
+	icon_state = "clothing"
+	steps = list(
+		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 60),
+		list(CRAFT_MATERIAL, 30, MATERIAL_STEEL, "time" = 60),
+		list(QUALITY_WELDING, 35, "time" = 60),
+		list(QUALITY_CUTTING, 30, "time" = 180),
+		list(QUALITY_HAMMERING, 30, "time" = 180),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 90),
+		list(/obj/item/tool_upgrade/reinforcement/rubbermesh, 1),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 120),
+		list(QUALITY_SAWING, 30, "time" = 60)
+	)
+
+//Robot Armor ----------------------
+
+/datum/craft_recipe/pirs/robotmelee //Lots of steps
+	name = "robot mark v armor plating"
+	result = /obj/item/robot_parts/robot_component/armour/mkv
+	steps = list(
+		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 90),
+		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 30),
+		list(QUALITY_WELDING, 35, "time" = 90),
+		list(QUALITY_CUTTING, 30, "time" = 180),
+		list(QUALITY_HAMMERING, 30, "time" = 180),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 90),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 120),
+		list(QUALITY_SAWING, 30, "time" = 60)
+	)
+
+//Tools --------------------------
+
+/datum/craft_recipe/pirs/combat_shovel
+	name = "combat crovel"
+	result = /obj/item/tool/shovel/combat
+	steps = list(
+		list(/obj/item/tool/shovel, 1),
+		list(QUALITY_SAWING, 20, "time" = 40),
+		list(QUALITY_HAMMERING, 30, "time" = 40),
+		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 20, "time" = 30),
+		list(/obj/item/tool_upgrade/augment/spikes, 1),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 10)
+	)
+
+//Weapons ------------------------
+/* Kept as reference. These are literally terrible LOL
+/datum/craft_recipe/pirs/nanopistol
+	name = "MKI Forger compressed-matter pistol"
+	result = /obj/item/gun/projectile/matter_gun
+	steps = list(
+		list(CRAFT_MATERIAL, 15, MATERIAL_PLASTEEL, "time" = 15),
+		list(QUALITY_CUTTING, 30, "time" = 10),
+		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTIC, "time" = 15),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 20),
+		list(/obj/item/cell/medium, 1, "time" = 5),
+		list(/obj/item/computer_hardware/tesla_link, 1, "time" = 10),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
+		list(/obj/item/stack/cable_coil, 10, "time" = 15),
+		list(QUALITY_WIRE_CUTTING, 40, "time" = 15),
+		list(/obj/item/stock_parts/manipulator/nano, 1, "time" = 15),
+		list(/obj/item/stock_parts/matter_bin/adv, 1, "time" = 5),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
+	)
+
+/datum/craft_recipe/pirs/nanoshotgun
+	name = "MKII Forger compressed-matter shotgun"
+	result = /obj/item/gun/projectile/matter_gun/shotgun
+	steps = list(
+		list(/obj/item/gun/projectile/matter_gun, 1, "time" = 15),
+		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 15),
+		list(QUALITY_CUTTING, 30, "time" = 10),
+		list(CRAFT_MATERIAL, 12, MATERIAL_PLASTIC, "time" = 15),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 20),
+		list(/obj/item/cell/large, 1, "time" = 5),
+		list(/obj/item/computer_hardware/tesla_link, 1, "time" = 10),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
+		list(/obj/item/stack/cable_coil, 20, "time" = 15),
+		list(QUALITY_WIRE_CUTTING, 40, "time" = 15),
+		list(/obj/item/stock_parts/capacitor/handmade, 1, "time" = 10),
+		list(/obj/item/stock_parts/micro_laser/handmade, 1, "time" = 10),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
+	)
+*/
+/* Kept for reference for now. Replacement soon (tm)
+//An exspensive but powerful CQC weapon that also can be used as a flar gun
+/datum/craft_recipe/pirs/abdicatorshotgun
+	name ="abdicator energy shotgun"
+	result = /obj/item/gun/energy/laser/railgun/abdicator
+	steps = list(
+		list(CRAFT_MATERIAL, 20, MATERIAL_PLASTEEL, "time" = 15),
+		list(QUALITY_CUTTING, 30, "time" = 10),
+		list(CRAFT_MATERIAL, 4, MATERIAL_PLASMA, "time" = 15),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 20),
+		list(QUALITY_HAMMERING, 10, "time" = 20),
+		list(/obj/item/stock_parts/smes_coil, 1, "time" = 5),
+		list(QUALITY_WELDING, 35, "time" = 15),
+		list(/obj/item/cell/large, 1, "time" = 5),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
+		list(/obj/item/stack/cable_coil, 30, "time" = 15),
+		list(QUALITY_WIRE_CUTTING, 40, "time" = 15),
+		list(/obj/item/stock_parts/subspace/ansible, 1, "time" = 1),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
+		list(CRAFT_MATERIAL, 10, MATERIAL_WOOD, "time" = 20),
+		list(QUALITY_HAMMERING, 30, "time" = 20),
+		list(CRAFT_MATERIAL, 6, MATERIAL_RGLASS, "time" = 10),
+		list(/obj/item/stock_parts/capacitor/adv, 1, "time" = 10),
+		list(/obj/item/stock_parts/micro_laser/high, 1, "time" = 10),
+		list(/obj/item/computer_hardware/tesla_link, 1, "time" = 10),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS, "time" = 20),
+		list(CRAFT_MATERIAL, 1, MATERIAL_URANIUM, "time" = 20),
+		list(QUALITY_HAMMERING, 40, "time" = 30),
+		list(CRAFT_MATERIAL, 15, MATERIAL_PLASTIC, "time" = 20),
+		list(CRAFT_MATERIAL, 4, MATERIAL_STEEL, "time" = 5),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 5)
+	)
+*/
+
+/datum/craft_recipe/pirs/bastion
+	name = "Bastion Shield"
+	result = /obj/item/shield/riot/bastion
+	steps = list(
+	list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL, "time" = 30),
+	list(QUALITY_SAWING, 30, "time" = 60),
+	list(CRAFT_MATERIAL, 2, MATERIAL_STEEL, "time" = 30),
+	list(QUALITY_WELDING, 35, "time"= 60),
+	list(/obj/item/shield/riot, 1, "time" = 30),
+	list(QUALITY_HAMMERING, 45, "time" = 40),
+	list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS, "time" = 30)
+	)
+
+
+//Wearables =========================
+
+/datum/craft_recipe/pirs/sheet_stacker
+	name = "advanced sheet snatcher"
+	icon_state = "woodworking"
+	result = /obj/item/storage/bag/sheetsnatcher/guild
+	steps = list(
+		list(CRAFT_MATERIAL, 10, MATERIAL_WOOD, "time" = 30),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
+		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL, "time" = 60),
+		list(QUALITY_ADHESIVE, 10, "time" = 60),
+		list(/obj/item/stack/cable_coil, 30, "time" = 30),
+		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
+	)
+
+//Tool/Gun Mods ---------------------
+//Reinforcement
+
+/datum/craft_recipe/pirs/rubbermesh
+	name = "Rubber Mesh"
+	result = /obj/item/tool_upgrade/reinforcement/rubbermesh
+	steps = list(
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC, "time" = 30),
+		list(QUALITY_WIRE_CUTTING, 20, "time" = 90)
+	)
+
+//Productivity
+/datum/craft_recipe/pirs/booster
+	name = "Booster"
+	result = /obj/item/tool_upgrade/productivity/booster
+	steps = list(
+		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL, "time" = 30),
+		list(QUALITY_HAMMERING, 30, "time" = 40),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
+		list(QUALITY_SCREW_DRIVING, 25, "time" = 90),
+		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD, "time" = 30),
+		list(QUALITY_BOLT_TURNING, 20, "time" = 40)
+	)
+
+//Gun Mods
+/datum/craft_recipe/pirs/weintraub
+	name = "\"Hurricane\" full auto kit"
+	result = /obj/item/gun_upgrade/mechanism/weintraub
+	icon_state = "gun"
+	steps = list(
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_SAWING, 30, "time" = 60),
+		list(QUALITY_HAMMERING, 20, "time" = 40),
+		list(QUALITY_WELDING, 35, "time" = 40),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
+		list(QUALITY_SCREW_DRIVING, 25, "time" = 90)
+	)
+
+//Gun Mods
+/datum/craft_recipe/pirs/overshooter
+	name = "\"Overshooter\" internal magazine kit"
+	result = /obj/item/gun_upgrade/mechanism/overshooter
+	icon_state = "gun"
+	steps = list(
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_SAWING, 30, "time" = 60),
+		list(QUALITY_HAMMERING, 20, "time" = 40),
+		list(QUALITY_WELDING, 35, "time" = 40),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
+		list(QUALITY_SCREW_DRIVING, 25, "time" = 90)
+	)
+
+/datum/craft_recipe/pirs/dangerzone
+	name = "\"Danger Zone\" Trigger"
+	result = /obj/item/gun_upgrade/trigger/dangerzone
+	icon_state = "gun"
+	steps = list(
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_SAWING, 30, "time" = 60),
+		list(QUALITY_HAMMERING, 20, "time" = 40),
+		list(QUALITY_WELDING, 35, "time" = 40),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
+		list(QUALITY_BOLT_TURNING, 25, "time" = 90)
+	)
+
+/datum/craft_recipe/pirs/forged
+	name = "Reinforced Barrel"
+	result = /obj/item/gun_upgrade/barrel/forged
+	icon_state = "gun"
+	steps = list(
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_SAWING, 30, "time" = 60),
+		list(QUALITY_HAMMERING, 20, "time" = 40),
+		list(QUALITY_WELDING, 35, "time" = 40),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC, "time" = 30),
+		list(QUALITY_BOLT_TURNING, 25, "time" = 90)
+	)
+
+/datum/craft_recipe/pirs/heavy_barrel
+	name = "Heavy barrel"
+	result = /obj/item/gun_upgrade/barrel/bore
+	icon_state = "gun"
+	steps = list(
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_SAWING, 30, "time" = 60),
+		list(QUALITY_HAMMERING, 20, "time" = 40),
+		list(QUALITY_WELDING, 35, "time" = 40),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTIC, "time" = 30),
+		list(QUALITY_BOLT_TURNING, 25, "time" = 90),
+		list(QUALITY_SAWING, 30, "time" = 60),
+		list(QUALITY_HAMMERING, 20, "time" = 40),
+		list(QUALITY_WELDING, 35, "time" = 40),
+		list(QUALITY_DRILLING, 60, "time" = 90),
+		list(/obj/item/tool_upgrade/refinement/ported_barrel, 1, "time" = 30),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_BOLT_TURNING, 25, "time" = 90)
+	)
+
+/datum/craft_recipe/pirs/silencer
+	name = "Silencer"
+	result = /obj/item/gun_upgrade/muzzle/silencer
+	icon_state = "gun"
+	steps = list(
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_SAWING, 30, "time" = 60),
+		list(QUALITY_HAMMERING, 20, "time" = 40),
+		list(QUALITY_WELDING, 35, "time" = 40),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
+		list(QUALITY_CUTTING, 25, "time" = 90)
+	)
+
+/datum/craft_recipe/pirs/watchman
+	name = "PIRS \"All Seeing\" scope"
+	result = /obj/item/gun_upgrade/scope/watchman
+	icon_state = "gun"
+	steps = list(
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_SAWING, 30, "time" = 60),
+		list(QUALITY_HAMMERING, 20, "time" = 40),
+		list(QUALITY_WELDING, 35, "time" = 40),
+		list(CRAFT_MATERIAL, 2, MATERIAL_GLASS, "time" = 30),
+		list(QUALITY_CUTTING, 25, "time" = 90)
+	)
+/*
+//Traps
+/datum/craft_recipe/pirs/guild_mine_trap
+	name = "land mine trap"
+	result = /obj/item/mine
+	icon_state = "gun"
+	steps = list(
+		list(/obj/item/mine/improvised, 1, "time" = 120),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 20, MATERIAL_STEEL),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(/obj/item/stack/cable_coil, 2, "time" = 10)
+	)*/
+//Machines & Mechs
+
+/datum/craft_recipe/pirs/safety_clamp
+	name = "Hydraulic clamp overclock: KILL CLAMP"
+	result = /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
+	steps = list(
+		list(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp, 1, "time" = 60),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 40),
+		list(/obj/item/tool_upgrade/productivity/motor, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(/obj/item/tool_upgrade/augment/hydraulic, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL),
+		list(QUALITY_WELDING, 30, "time" = 40),
+		list(/obj/item/tool_upgrade/augment/spikes, 1, "time" = 60)
+	)
+
+/datum/craft_recipe/pirs/tesla_energy_relay
+	name = "Mech energy relay"
+	result = /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
+	steps = list(
+		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 30),
+		list(QUALITY_WELDING, 45, "time" = 40),
+		list(QUALITY_BOLT_TURNING, 30, 70),
+		list(/obj/item/computer_hardware/tesla_link, 2, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(/obj/item/stack/cable_coil, 15, "time" = 90),
+		list(QUALITY_WIRE_CUTTING, 25, "time" = 90),
+		list(/obj/item/stock_parts/capacitor/super, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD)
+	)
+
+/datum/craft_recipe/pirs/guild_bin
+	name = "Hand Giga Matter Bin"
+	result = /obj/item/stock_parts/matter_bin/handmade
+	steps = list(
+		list(/obj/item/stock_parts/matter_bin/super, 1),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL), //Quite useless in most cases so were cheaper
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(QUALITY_HAMMERING, 40),
+		list(QUALITY_SAWING, 60)
+	)
+
+/datum/craft_recipe/pirs/guild_manip
+	name = "Perfected Flexi-Pico Manipulator"
+	result = /obj/item/stock_parts/manipulator/handmade
+	steps = list(
+		list(/obj/item/stock_parts/manipulator/pico, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL), //Are main thing were exspensive do to being the main crafted item
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(/obj/item/stack/cable_coil, 10),
+		list(QUALITY_HAMMERING, 40),
+		list(QUALITY_SAWING, 60)
+	)
+
+/datum/craft_recipe/pirs/guild_laser
+	name = "Handmade Perfected Ultra High Power Micro-Lasers"
+	result = /obj/item/stock_parts/micro_laser/handmade
+	steps = list(
+		list(/obj/item/stock_parts/micro_laser/ultra, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
+		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(QUALITY_SAWING, 60)
+	)
+
+/datum/craft_recipe/pirs/guild_scanner
+	name = "Overtuned Scanning Module"
+	result = /obj/item/stock_parts/scanning_module/handmade
+	steps = list(
+		list(/obj/item/stock_parts/scanning_module/phasic, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
+		list(QUALITY_SAWING, 60)
+	)
+
+/datum/craft_recipe/pirs/guild_capacitor
+	name = "Crafted Experimental Capacitor"
+	result = /obj/item/stock_parts/capacitor/handmade
+	steps = list(
+		list(/obj/item/stock_parts/capacitor/super, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
+		list(QUALITY_SAWING, 60)
+	)
+/*
+/datum/craft_recipe/pirs/guild_manip_alt
+	name = "Forged Manipulator Alt"
+	result = /obj/item/stock_parts/manipulator/handmade
+	steps = list(
+		list(/obj/item/stock_parts/manipulator/nano, 2),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL),
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(/obj/item/stack/cable_coil, 10),
+		list(QUALITY_HAMMERING, 40),
+		list(QUALITY_SAWING, 60)
+	)
+
+/datum/craft_recipe/pirs/guild_laser_alt
+	name = "Perfected Micro-Laser Alt"
+	result = /obj/item/stock_parts/micro_laser/handmade
+	steps = list(
+		list(/obj/item/stock_parts/micro_laser/high, 2),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
+		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(QUALITY_SAWING, 60)
+	)
+
+/datum/craft_recipe/pirs/guild_scanner_alt
+	name = "Perfected Scanning Module Alt"
+	result = /obj/item/stock_parts/scanning_module/handmade
+	steps = list(
+		list(/obj/item/stock_parts/scanning_module/adv, 2),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 2, MATERIAL_SILVER),
+		list(QUALITY_SAWING, 60)
+	)
+
+/datum/craft_recipe/pirs/guild_capacitor_alt
+	name = "Crafted Ultra Capacitor Alt"
+	result = /obj/item/stock_parts/capacitor/handmade
+	steps = list(
+		list(/obj/item/stock_parts/capacitor/adv, 2),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 2, MATERIAL_SILVER),
+		list(QUALITY_SAWING, 60)
+	)
+*/
+// Fixes a matdupe here. Please ensure these are never cheaper to make than anything else.
+/datum/craft_recipe/pirs/guild_bin_box
+	name = "Box of Giga Matter Bins"
+	result = /obj/item/storage/box/guild_bin
+	steps = list(
+		list(/obj/item/stock_parts/matter_bin/super, 4),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 4, MATERIAL_PLASTEEL),
+		list(CRAFT_MATERIAL, 4, MATERIAL_PLASMAGLASS),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(QUALITY_HAMMERING, 40),
+		list(QUALITY_SAWING, 60),
+		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
+	)
+
+/datum/craft_recipe/pirs/guild_manip_box
+	name = "Box of Flexi-Pico Manipulators"
+	result = /obj/item/storage/box/guild_manip
+	steps = list(
+		list(/obj/item/stock_parts/manipulator/pico, 4),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 8, MATERIAL_PLASTEEL),
+		list(CRAFT_MATERIAL, 8, MATERIAL_PLASTIC),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(/obj/item/stack/cable_coil, 10),
+		list(QUALITY_HAMMERING, 40),
+		list(QUALITY_SAWING, 60),
+		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
+	)
+
+/datum/craft_recipe/pirs/guild_laser_box
+	name = "Box of Perfected Ultra High Power Micro-Lasers"
+	result = /obj/item/storage/box/guild_laser
+	steps = list(
+		list(/obj/item/stock_parts/micro_laser/ultra, 4),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 4, MATERIAL_PLASMAGLASS),
+		list(CRAFT_MATERIAL, 4, MATERIAL_RGLASS),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(QUALITY_SAWING, 60),
+		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
+	)
+
+/datum/craft_recipe/pirs/guild_scanner_box
+	name = "Box of Over-Tuned Scanning Modules"
+	result = /obj/item/storage/box/guild_scanner
+	steps = list(
+		list(/obj/item/stock_parts/scanning_module/phasic, 4),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 4, MATERIAL_GOLD),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 4, MATERIAL_SILVER),
+		list(QUALITY_SAWING, 60),
+		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
+	)
+
+/datum/craft_recipe/pirs/guild_capacitor_box
+	name = "Box of Crafted Experimental Capacitors"
+	result = /obj/item/storage/box/guild_capacitor
+	steps = list(
+		list(/obj/item/stock_parts/capacitor/super, 4),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 4, MATERIAL_GOLD),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 4, MATERIAL_SILVER),
+		list(QUALITY_SAWING, 60),
+		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
+	)

--- a/code/datums/craft/recipes/pirs.dm
+++ b/code/datums/craft/recipes/pirs.dm
@@ -396,8 +396,8 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
 		list(QUALITY_BOLT_TURNING, 10, 70),
 		list(QUALITY_WELDING, 35),
-		list(QUALITY_HAMMERING, 40),
-		list(QUALITY_SAWING, 60)
+		list(QUALITY_HAMMERING, 30),
+		list(QUALITY_SAWING, 30)
 	)
 
 /datum/craft_recipe/pirs/guild_manip
@@ -411,8 +411,8 @@
 		list(QUALITY_BOLT_TURNING, 10, 70),
 		list(QUALITY_WELDING, 35),
 		list(/obj/item/stack/cable_coil, 10),
-		list(QUALITY_HAMMERING, 40),
-		list(QUALITY_SAWING, 60)
+		list(QUALITY_HAMMERING, 30),
+		list(QUALITY_SAWING, 30)
 	)
 
 /datum/craft_recipe/pirs/guild_laser
@@ -425,7 +425,7 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
 		list(QUALITY_BOLT_TURNING, 10, 70),
 		list(QUALITY_WELDING, 35),
-		list(QUALITY_SAWING, 60)
+		list(QUALITY_SAWING, 30)
 	)
 
 /datum/craft_recipe/pirs/guild_scanner
@@ -438,7 +438,7 @@
 		list(QUALITY_BOLT_TURNING, 10, 70),
 		list(QUALITY_WELDING, 35),
 		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60)
+		list(QUALITY_SAWING, 30)
 	)
 
 /datum/craft_recipe/pirs/guild_capacitor
@@ -451,7 +451,7 @@
 		list(QUALITY_BOLT_TURNING, 10, 70),
 		list(QUALITY_WELDING, 35),
 		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60)
+		list(QUALITY_SAWING, 30)
 	)
 /*
 /datum/craft_recipe/pirs/guild_manip_alt

--- a/code/game/objects/items/weapons/stock_parts.dm
+++ b/code/game/objects/items/weapons/stock_parts.dm
@@ -206,10 +206,10 @@
 	matter = list(MATERIAL_PLASTIC = 3, MATERIAL_GLASS = 1, MATERIAL_PLATINUM = 2)
 	price_tag = 40
 
-//Guild stock parts (rating 4)
+//PIRS stock parts (rating 4) - DO NOT USE THESE. MAKE THEM CRAFT THEM.
 /obj/item/stock_parts/capacitor/guild
 	name = "ultra capacitor"
-	desc = "A guild tinkered super-high capacity capacitor used in the construction of a variety of devices."
+	desc = "A PIRS tinkered super-high capacity capacitor used in the construction of a variety of devices."
 	icon_state = "guild_capacitor"
 	origin_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
 	rating = 4
@@ -252,51 +252,51 @@
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_GLASS = 1, MATERIAL_PLASMAGLASS = 1)
 	price_tag = 75
 
-//Guild stock parts (rating 5)
+//PIRS stock parts (rating 5)
 /obj/item/stock_parts/capacitor/handmade
-	name = "handcrafted ultra capacitor"
-	desc = "A guild tinkered super-high capacity capacitor used in the construction of a variety of devices. Being made by hand by the skilled Guild shows that they can out perform even a Nanoforge."
+	name = "experimental capacitor"
+	desc = "A PIRS tinkered super-high capacity capacitor used in the construction of a variety of devices. Being hand-tuned and impedence tested; along with extra-conductive wiring replacing the original connectors - these easily outperform their lathe-printed counterparts."
 	icon_state = "guild_capacitor"
 	origin_tech = list(TECH_POWER = 5, TECH_MATERIAL = 4)
 	rating = 5
-	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1, MATERIAL_GOLD  = 2, MATERIAL_SILVER = 2)
-	price_tag = 200
+	matter = list(MATERIAL_STEEL = 1, MATERIAL_PLASTIC = 1, MATERIAL_GLASS = 1, MATERIAL_GOLD  = 1, MATERIAL_SILVER = 1) //Sorry, you want me to use 2 sheets of gold and silver for ONE capacitor? Fat chance.
+	price_tag = 800 //Why were these so cheap? ORIGINAL: 200
 
 /obj/item/stock_parts/scanning_module/handmade
-	name = "handcrafted over-tuned scanning module"
-	desc = "An over engineered and expensive yet compact, high resolution phasic scanning module used in the construction of certain devices. Being made by hand by the skilled Guild shows that they can out perform even a Nanoforge."
+	name = "over-tuned scanning module"
+	desc = "An over engineered and high resolution, yet compact phasic scanning module used in the construction of certain devices. Being tuned by hand to run at the optimum frequency for their scanning efforts; these easily blow lathe-fabricated ones out of the water.."
 	icon_state = "guild_scan_module"
 	origin_tech = list(TECH_MAGNET = 5)
 	rating = 5
-	matter = list(MATERIAL_STEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_RGLASS  = 1, MATERIAL_GOLD  = 2, MATERIAL_SILVER = 2)
-	price_tag = 200
+	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_RGLASS  = 1, MATERIAL_GOLD  = 1, MATERIAL_SILVER = 1)
+	price_tag = 800 //Why were these so cheap? ORIGINAL: 200
 
 /obj/item/stock_parts/manipulator/handmade
-	name = "handcrafted forged manipulator"
-	desc = "A buffed up pico manipulator with a added case to increase manipulation used in the construction of certain devices. Being made by hand by the skilled Guild shows that they can out perform even a Nanoforge."
+	name = "flexi-pico manipulator"
+	desc = "A beefed up picomanipulator - many un-neccessary parts that slowed previous fabrication efforts having been removed, slimmed down and redesigned from the ground-up. Such modifications make it many times better than a lathe-printed counterpart; and faster, too!"
 	icon_state = "guild_mani"
 	origin_tech = list(TECH_MATERIAL = 5, TECH_DATA = 2)
 	rating = 5
-	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 5)
-	price_tag = 200
+	matter = list(MATERIAL_PLASTEEL = 2, MATERIAL_PLASTIC = 1) //Point and case.
+	price_tag = 800 //Why were these so cheap? ORIGINAL: 200
 
 /obj/item/stock_parts/micro_laser/handmade
-	name = "handcrafted perfected micro-laser"
+	name = "perfected ultra-high-power micro-laser"
 	icon_state = "guild_micro_laser"
-	desc = "An ultra-high micro laser with a perfected lens to increase productivity. Being made by hand by the skilled Guild shows that they can out perform even a Nanoforge."
+	desc = "An ultra-high micro laser with a compound lense to decrease beam divergence and increase peak power output. Being made by skilled tinkerers; this also features a better driver circuit, extra thermal coupling - and a more powerful diode, easily outperforming lathe counterparts."
 	origin_tech = list(TECH_MAGNET = 5)
 	rating = 5
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1, MATERIAL_RGLASS = 1, MATERIAL_SILVER = 1)
-	price_tag = 200
+	price_tag = 800 //Why were these so cheap? ORIGINAL: 200
 
 /obj/item/stock_parts/matter_bin/handmade
-	name = "handcrafted cast matter bin"
-	desc = "A super matter bin with added compression cast onto the base itself for more effective storage. Being made by hand by the skilled Guild shows that they can out perform even a Nanoforge."
+	name = "giga matter bin"
+	desc = "A super matter bin combined with extra compression storage, faster cyclic speeds; and generally higher capacity per second. Such modifications increase the bulk by a decent bit - but they clearly blow their lathe-fabricated counterparts out of the water!"
 	icon_state = "guild_matter_bin"
 	origin_tech = list(TECH_MATERIAL = 5)
 	rating = 5
-	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_GLASS = 2, MATERIAL_STEEL = 1)
-	price_tag = 200
+	matter = list(MATERIAL_PLASTEEL = 2, MATERIAL_GLASS = 1, MATERIAL_STEEL = 1)
+	price_tag = 800 //Why were these so cheap? ORIGINAL: 200
 
 //excelsior stock parts (rating 5)
 /obj/item/stock_parts/capacitor/excelsior

--- a/code/modules/clothing/glasses/powered.dm
+++ b/code/modules/clothing/glasses/powered.dm
@@ -97,7 +97,7 @@
 
 /obj/item/clothing/glasses/powered/night/guild
 	name = "optimized meson-NVG goggles"
-	desc = "Enhanced from boring mesons, this refined Union design sports the benefits from the mesons power-saving making these last ~60% longer than other NV goggles on the market!"
+	desc = "Enhanced from boring mesons, this refined Union design sports the benefits from the mesons power-saving making these last ~40-60% longer than other NV goggles on the market!"
 	icon_state = "guild" // New sprites by Dromkii aka Ezoken#5894 !
 	item_state = "guild"
 	off_state = "deguild"
@@ -107,7 +107,7 @@
 	origin_tech = list(TECH_MAGNET = 3)
 	price_tag = 350
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_GLASS = 2, MATERIAL_PLASTEEL = 2, MATERIAL_URANIUM = 1)
-	tick_cost = 0.12 // 20% more battery life so you have a reason to go to the guild and get these
+	tick_cost = 0.2 // ~40% more battery life so you have a reason to go to the guild and get these
 
 
 /obj/item/clothing/glasses/powered/night/guild/crafted

--- a/code/modules/clothing/glasses/powered.dm
+++ b/code/modules/clothing/glasses/powered.dm
@@ -96,17 +96,18 @@
 	screenOverlay = global_hud.nvg
 
 /obj/item/clothing/glasses/powered/night/guild
-	name = "optimized night vision goggles"
-	desc = "Converted from boring mesons, this refined Guild design sports the benefits form the mesons power-saving making these last 20% longer than other NV goggles on the market!"
+	name = "optimized meson-NVG goggles"
+	desc = "Enhanced from boring mesons, this refined Union design sports the benefits from the mesons power-saving making these last ~60% longer than other NV goggles on the market!"
 	icon_state = "guild" // New sprites by Dromkii aka Ezoken#5894 !
 	item_state = "guild"
 	off_state = "deguild"
 	darkness_view = 7
+	vision_flags = SEE_TURFS
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	origin_tech = list(TECH_MAGNET = 3)
 	price_tag = 350
 	matter = list(MATERIAL_STEEL = 2, MATERIAL_GLASS = 2, MATERIAL_PLASTEEL = 2, MATERIAL_URANIUM = 1)
-	tick_cost = 0.33 // 20% more battery life so you have a reason to go to the guild and get these
+	tick_cost = 0.12 // 20% more battery life so you have a reason to go to the guild and get these
 
 
 /obj/item/clothing/glasses/powered/night/guild/crafted

--- a/code/modules/projectiles/guns/mods/mods.dm
+++ b/code/modules/projectiles/guns/mods/mods.dm
@@ -75,7 +75,7 @@
 //Decreases fire delay. Acquired through loot spawns or guild crafting
 /obj/item/gun_upgrade/barrel/forged
 	name = "Forged barrel"
-	desc = "Despite advancements in 3D printing, a properly forged plasteel barrel can still outperform anything that comes from an autolathe."
+	desc = "Despite advancements in 3D printing, a properly reinforced plasteel barrel can still outperform anything that comes from an autolathe."
 	icon_state = "Forged_barrel"
 	price_tag = 120
 
@@ -284,7 +284,7 @@
 //Adds +3 to the internal magazine of a weapon. Acquired through loot spawns.
 /obj/item/gun_upgrade/mechanism/overshooter
 	name = "\"Overshooter\" internal magazine kit"
-	desc = "A method of overloading a weapon's internal magazine, fitting more ammunition within the weapon. An Terra-Therma Union favorite for revolvers and shotguns."
+	desc = "A method of overloading a weapon's internal magazine, fitting more ammunition within the weapon. A Rancher's favorite for revolvers and shotguns."
 	icon_state = "Overshooter"
 	price_tag = 230
 
@@ -682,8 +682,8 @@
 //	bad_type = /obj/item/gun_upgrade/scope
 
 /obj/item/gun_upgrade/scope/watchman
-	name = "Terra-Therma Union \"Watchman\" scope"
-	desc = "In the age of 3D printing, the design of a scope one can rely on is common, but a scope that is special is a rarity. Hand-made scopes forged by the Terra-Therma Union are known across the entire Solarian Federation for the quality they have and this one is no different."
+	name = "PIRS \"All Seeing\" scope"
+	desc = "In an age where lathe-printed parts are too common; these scopes stand out an oddity. From the PIRS Weapons Division; these are made with reinforced glass, with a plasteel frame - each one manually polished and made by 'hand', undoubtedly by lines of fabrication synthetics."
 	icon_state = "Watchman"
 	matter = list(MATERIAL_GLASS = 2, MATERIAL_PLASTEEL = 1)
 	price_tag = 40

--- a/liberty-station.dme
+++ b/liberty-station.dme
@@ -358,6 +358,7 @@
 #include "code\datums\craft\recipes\machinery.dm"
 #include "code\datums\craft\recipes\medical.dm"
 #include "code\datums\craft\recipes\misc.dm"
+#include "code\datums\craft\recipes\pirs.dm"
 #include "code\datums\craft\recipes\repairs.dm"
 #include "code\datums\craft\recipes\robot.dm"
 #include "code\datums\craft\recipes\storage.dm"


### PR DESCRIPTION
Guild VS PRS
## Changelog
:cl:
add: Most union recipes to PIRS
del: Most union recipes from union
add: New union recipes
tweak: NVGMesons exist properly now
tweak: Lots of union recipes are now cheaper than the PIRS alternatives.
QOL: Union things are generally cheaper + faster to make (and more worthwhile)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
