### PR TITLE
vermouth missing energy drink fix

### DIFF
--- a/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
+++ b/code/modules/trade/datums/trade_stations_presets/1-common/boozefood.dm
@@ -102,7 +102,8 @@
 			/obj/item/reagent_containers/food/drinks/cans/monster_jungel,
 			/obj/item/reagent_containers/food/drinks/cans/monster_church,
 			/obj/item/reagent_containers/food/drinks/cans/monster_red,
-			/obj/item/reagent_containers/food/drinks/cans/monster_blue
+			/obj/item/reagent_containers/food/drinks/cans/monster_blue,
+			/obj/item/reagent_containers/food/drinks/cans/energy
 		)
 	)
 


### PR DESCRIPTION
adds the "render" energy drink that for some reason was not grouped with the rest of the energy drinks code wise to vermouth station.