### PR TITLE
precursor bug fix pass 01

### DIFF
--- a/code/modules/dungeons/procedural/precursor.dm
+++ b/code/modules/dungeons/procedural/precursor.dm
@@ -111,11 +111,19 @@ var/precursor_test = FALSE
 	desc = "A pad warped in thru bluespace to ensure a more stable portal."
 	var/starter_room = FALSE
 
+/obj/item/device/precursor/scan_capsule
+	name = "P.S.D. positioning data"
+	desc = "A cube containing the data for another section of ice sheet."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "psi_catalyst"
+	item_state = "psi_catalyst"
+
 /obj/machinery/precursor_dungeon_device
 	name = "precursor systems device"
 	desc = "A advanced machine capable of finding ruins by vibrations in the ice sheets."
-	icon = 'icons/obj/virology.dmi'
-	icon_state = "isolator"
+	icon = 'icons/obj/xenoarchaeology.dmi'
+	icon_state = "psionic_harvester"
+	density = 1
 
 	var/uses = 1
 	var/obj/procedural/dungenerator/precursor/precursor_controller = null
@@ -144,6 +152,7 @@ var/precursor_test = FALSE
 		uses -= 1
 		precursor_controller.make_me_dungeon()
 		generated = TRUE
+		icon_state = "psionic_harvester_on"
 		return
 	if(generated)
 		for(var/mob/M in GLOB.player_list)
@@ -151,17 +160,20 @@ var/precursor_test = FALSE
 				to_chat(user, SPAN_NOTICE("You can't end the expidition right now, Someone is still out there!"))
 				return
 		to_chat(user, SPAN_NOTICE("The machine disconnects its links."))
+		icon_state = "psionic_harvester"
 		precursor_controller.Pgenerate.unlink()
 		precursor_controller.reset()
 
 /obj/machinery/precursor_dungeon_device/attackby(obj/item/I, mob/user)
-	if(istype(I,/obj/item/device/psionic_catalyst/dull))
+	if(istype(I,/obj/item/device/precursor/scan_capsule))
 		if(uses > 0)
 			to_chat(user, SPAN_NOTICE("The machine is already loaded and ready to go."))
 			return
 		else
 			to_chat(user, SPAN_NOTICE("You load the device into the [src]."))
 			uses += 1
+			user.drop_item()
+			qdel(I)
 			return
 
 /obj/effect/portal/jtb/precursor

--- a/maps/_dungeons/precursor/precursor.dmm
+++ b/maps/_dungeons/precursor/precursor.dmm
@@ -3,6 +3,10 @@
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/precursor/mini_base)
+"aD" = (
+/obj/structure/anomaly_container,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/precursor/mini_base)
 "aH" = (
 /obj/structure/table/woodentable,
 /obj/item/deck/cards,
@@ -148,6 +152,13 @@
 "qM" = (
 /turf/simulated/floor/wood/wild1,
 /area/precursor/mini_base)
+"re" = (
+/obj/structure/table/bench/wooden,
+/obj/item/clothing/head/helmet/space/anomaly,
+/obj/item/clothing/head/helmet/space/anomaly,
+/obj/item/clothing/head/helmet/space/anomaly,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/precursor/mini_base)
 "rp" = (
 /obj/machinery/artifact_scanpad/precursor,
 /turf/simulated/floor/rock/manmade/ruin1,
@@ -200,6 +211,13 @@
 /obj/effect/floor_decal/industrial_plant/steel_grate_alt,
 /turf/simulated/floor/rock/manmade/ruin1,
 /area/precursor/mini_base)
+"xA" = (
+/obj/structure/table/bench/wooden,
+/obj/item/tank/air,
+/obj/item/tank/air,
+/obj/item/tank/air,
+/turf/simulated/floor/tiled/steel/gray_perforated,
+/area/precursor/mini_base)
 "xI" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /obj/effect/floor_decal/industrial_plant/steel_grate_alt,
@@ -251,7 +269,7 @@
 /area/precursor/mini_base)
 "Ed" = (
 /obj/structure/table/reinforced,
-/obj/item/device/psionic_catalyst/dull,
+/obj/item/device/precursor/scan_capsule,
 /turf/simulated/floor/rock/manmade/ruin1,
 /area/precursor/mini_base)
 "Eq" = (
@@ -359,6 +377,13 @@
 /area/precursor/mini_base)
 "WS" = (
 /turf/simulated/floor/tiled/steel/brown_perforated,
+/area/precursor/mini_base)
+"XJ" = (
+/obj/structure/table/bench/wooden,
+/obj/item/clothing/suit/space/anomaly,
+/obj/item/clothing/suit/space/anomaly,
+/obj/item/clothing/suit/space/anomaly,
+/turf/simulated/floor/tiled/steel/gray_perforated,
 /area/precursor/mini_base)
 "Yi" = (
 /mob/living/simple_animal/snail,
@@ -1258,7 +1283,7 @@ zj
 kv
 kv
 mD
-YO
+xA
 zj
 UM
 nQ
@@ -1435,7 +1460,7 @@ jf
 mD
 MY
 MY
-YO
+XJ
 zj
 UM
 nQ
@@ -1612,7 +1637,7 @@ jf
 tu
 MY
 MY
-YO
+re
 zj
 UM
 nQ
@@ -2851,7 +2876,7 @@ UM
 mD
 mD
 mD
-mD
+aD
 zj
 UM
 nQ
@@ -3028,7 +3053,7 @@ DF
 mD
 MY
 MY
-mD
+aD
 zj
 UM
 nQ
@@ -3205,7 +3230,7 @@ DF
 tu
 MY
 MY
-mD
+aD
 zj
 UM
 nQ
@@ -3382,7 +3407,7 @@ zj
 mD
 MY
 MY
-mD
+aD
 zj
 UM
 nQ
@@ -3559,7 +3584,7 @@ zj
 mD
 mD
 mD
-mD
+aD
 zj
 UM
 nQ

--- a/maps/submaps/precursor_rooms/end/pruin_end1.dmm
+++ b/maps/submaps/precursor_rooms/end/pruin_end1.dmm
@@ -88,15 +88,12 @@
 	},
 /obj/random/pack/tech_loot,
 /obj/random/psi_catalyst,
-/obj/item/device/psionic_catalyst/dull{
-	name = "teleporter catalyst";
-	desc = "A unique catalyst created to provide enough power to a teleporter for just one more portal, it humms with endless possibilities and endless horrors."
-	},
 /obj/structure/invislightsmall{
 	light_color = "#A666B1";
 	light_power = 2;
 	light_range = 9
 	},
+/obj/item/device/precursor/scan_capsule,
 /turf/simulated/floor/rock/manmade/ruin1,
 /area/precursor)
 "E" = (


### PR DESCRIPTION
Changes dungeon reset item to be a unique item so you don't find the loot somewhere else by chance.
Adds a few things for the testing room so I don't die to lack of gas or the temp change from some anomaly.
Fixes up the PSD to have a better sprite by Gidgit and be solid.
Fixes PSD not actually consuming the dungeon reset item. (infinite reset fix)