### PR TITLE
#388 Augment

### DIFF
--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -32,7 +32,7 @@
 		list(QUALITY_SCREW_DRIVING, 20, "time" = 60),
 		list(QUALITY_BOLT_TURNING, 25, "time" = 40)
 	)
-
+/* Currently high end tool loot, and for Skylight
 /datum/craft_recipe/terra/omnitool
 	name = "Munchkin 5000"
 	result = /obj/item/tool/omnitool
@@ -45,7 +45,7 @@
 		list(QUALITY_SCREW_DRIVING, 20, "time" = 60),
 		list(QUALITY_BOLT_TURNING, 25, "time" = 40)
 	)
-
+*/
 /datum/craft_recipe/terra/polytool
 	name = "\"jolly co-operation\" polytool"
 	result = /obj/item/tool/polytool
@@ -267,7 +267,7 @@
 	list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS, "time" = 30)
 	)
 
-/datum/craft_recipe/pirs/safety_clamp
+/datum/craft_recipe/terra/safety_clamp
 	name = "Hydraulic clamp overclock: KILL CLAMP"
 	result = /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
 	steps = list(
@@ -442,60 +442,9 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER)
 	)
 
-/datum/craft_recipe/terra/guild_capacitor
-	name = "Crafted Super Capacitor"
-	result = /obj/item/stock_parts/capacitor/super
-	steps = list(
-		list(/obj/item/stock_parts/capacitor, 1),
-		list(QUALITY_SCREW_DRIVING, 35, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 35),
-		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
-		list(QUALITY_SAWING, 30)
-	)
-
-/datum/craft_recipe/terra/guild_manip
-	name = "Crafted Pico Manipulator"
-	result = /obj/item/stock_parts/manipulator/pico
-	steps = list(
-		list(/obj/item/stock_parts/manipulator, 1),
-		list(QUALITY_SCREW_DRIVING, 35, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 35),
-		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
-		list(QUALITY_SAWING, 30)
-	)
-
-/datum/craft_recipe/terra/guild_matterbin
-	name = "Crafted Super Matterbin"
-	result = /obj/item/stock_parts/matter_bin/super
-	steps = list(
-		list(/obj/item/stock_parts/matter_bin, 1),
-		list(QUALITY_SCREW_DRIVING, 35, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 35),
-		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
-		list(QUALITY_SAWING, 30)
-	)
-
-/datum/craft_recipe/terra/guild_laser
-	name = "Crafted Ultra High Power Laser"
-	result = /obj/item/stock_parts/micro_laser/ultra
-	steps = list(
-		list(/obj/item/stock_parts/micro_laser, 1),
-		list(QUALITY_SCREW_DRIVING, 35, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 35),
-		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
-		list(QUALITY_SAWING, 30)
-	)
 //T4 stock parts, if you want bulk crafts go to PIRS.
 
-/datum/craft_recipe/pirs/guild_bin
+/datum/craft_recipe/terra/handmade_bin
 	name = "Hand Giga Matter Bin"
 	result = /obj/item/stock_parts/matter_bin/handmade
 	steps = list(
@@ -509,7 +458,7 @@
 		list(QUALITY_SAWING, 30)
 	)
 
-/datum/craft_recipe/pirs/guild_manip
+/datum/craft_recipe/terra/handmade_manip
 	name = "Perfected Flexi-Pico Manipulator"
 	result = /obj/item/stock_parts/manipulator/handmade
 	steps = list(
@@ -524,7 +473,7 @@
 		list(QUALITY_SAWING, 30)
 	)
 
-/datum/craft_recipe/pirs/guild_laser
+/datum/craft_recipe/terra/handmade_laser
 	name = "Handmade Perfected Ultra High Power Micro-Lasers"
 	result = /obj/item/stock_parts/micro_laser/handmade
 	steps = list(
@@ -537,7 +486,7 @@
 		list(QUALITY_SAWING, 30)
 	)
 
-/datum/craft_recipe/pirs/guild_scanner
+/datum/craft_recipe/terra/handmade_scanner
 	name = "Overtuned Scanning Module"
 	result = /obj/item/stock_parts/scanning_module/handmade
 	steps = list(
@@ -550,7 +499,7 @@
 		list(QUALITY_SAWING, 30)
 	)
 
-/datum/craft_recipe/pirs/guild_capacitor
+/datum/craft_recipe/terra/handmade_capacitor
 	name = "Crafted Experimental Capacitor"
 	result = /obj/item/stock_parts/capacitor/handmade
 	steps = list(

--- a/code/datums/craft/recipes/guild.dm
+++ b/code/datums/craft/recipes/guild.dm
@@ -267,6 +267,20 @@
 	list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS, "time" = 30)
 	)
 
+/datum/craft_recipe/pirs/safety_clamp
+	name = "Hydraulic clamp overclock: KILL CLAMP"
+	result = /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
+	steps = list(
+		list(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp, 1, "time" = 60),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 40),
+		list(/obj/item/tool_upgrade/productivity/motor, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(/obj/item/tool_upgrade/augment/hydraulic, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL),
+		list(QUALITY_WELDING, 30, "time" = 40),
+		list(/obj/item/tool_upgrade/augment/spikes, 1, "time" = 60)
+	)
 
 //Wearables =========================
 /datum/craft_recipe/terra/nv_guild
@@ -343,7 +357,7 @@
 		list(/obj/item/storage/pouch/medium_generic, 1, "time" = 40)
 	)
 
-/datum/craft_recipe/terra/sheet_stacker //Cheaper than the PIRS recipe.
+/datum/craft_recipe/terra/sheet_stacker
 	name = "advanced sheet snatcher"
 	icon_state = "woodworking"
 	result = /obj/item/storage/bag/sheetsnatcher/guild
@@ -354,17 +368,6 @@
 		list(QUALITY_ADHESIVE, 10, "time" = 60),
 		list(/obj/item/stack/cable_coil, 30, "time" = 30),
 		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL, "time" = 30),
-	)
-
-//Tool/Gun Mods ---------------------
-//Reinforcement
-
-/datum/craft_recipe/terra/rubbermesh
-	name = "Rubber Mesh"
-	result = /obj/item/tool_upgrade/reinforcement/rubbermesh
-	steps = list(
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30), //Cheaper
-		list(QUALITY_WIRE_CUTTING, 20, "time" = 90)
 	)
 
 //Productivity
@@ -488,5 +491,74 @@
 		list(QUALITY_BOLT_TURNING, 10, 70),
 		list(QUALITY_WELDING, 35),
 		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
+		list(QUALITY_SAWING, 30)
+	)
+//T4 stock parts, if you want bulk crafts go to PIRS.
+
+/datum/craft_recipe/pirs/guild_bin
+	name = "Hand Giga Matter Bin"
+	result = /obj/item/stock_parts/matter_bin/handmade
+	steps = list(
+		list(/obj/item/stock_parts/matter_bin/super, 1),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL), //Quite useless in most cases so were cheaper
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(QUALITY_HAMMERING, 30),
+		list(QUALITY_SAWING, 30)
+	)
+
+/datum/craft_recipe/pirs/guild_manip
+	name = "Perfected Flexi-Pico Manipulator"
+	result = /obj/item/stock_parts/manipulator/handmade
+	steps = list(
+		list(/obj/item/stock_parts/manipulator/pico, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTEEL), //Are main thing were exspensive do to being the main crafted item
+		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(/obj/item/stack/cable_coil, 10),
+		list(QUALITY_HAMMERING, 30),
+		list(QUALITY_SAWING, 30)
+	)
+
+/datum/craft_recipe/pirs/guild_laser
+	name = "Handmade Perfected Ultra High Power Micro-Lasers"
+	result = /obj/item/stock_parts/micro_laser/handmade
+	steps = list(
+		list(/obj/item/stock_parts/micro_laser/ultra, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
+		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(QUALITY_SAWING, 30)
+	)
+
+/datum/craft_recipe/pirs/guild_scanner
+	name = "Overtuned Scanning Module"
+	result = /obj/item/stock_parts/scanning_module/handmade
+	steps = list(
+		list(/obj/item/stock_parts/scanning_module/phasic, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
+		list(QUALITY_SAWING, 30)
+	)
+
+/datum/craft_recipe/pirs/guild_capacitor
+	name = "Crafted Experimental Capacitor"
+	result = /obj/item/stock_parts/capacitor/handmade
+	steps = list(
+		list(/obj/item/stock_parts/capacitor/super, 1),
+		list(QUALITY_SCREW_DRIVING, 35, 70),
+		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD),
+		list(QUALITY_BOLT_TURNING, 10, 70),
+		list(QUALITY_WELDING, 35),
+		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
 		list(QUALITY_SAWING, 30)
 	)

--- a/code/datums/craft/recipes/pirs.dm
+++ b/code/datums/craft/recipes/pirs.dm
@@ -2,23 +2,10 @@
 	category = "PIRS"
 	time = 100
 	related_stats = list(STAT_COG)
-	requiredPerk = PERK_SCIENCE
+	requiredPerk = PERK_SCIENCE // Todo, make a Science_Armorer perk or something so the CAPSA Overseers aren't omnicrafters
 
-//Materal Craft ------------------
-//bullets -----------------------------
 
-/datum/craft_recipe/pirs/payload_arrow
-	name = "bulk empty payload arrow"
-	result = /obj/item/ammo_casing/arrow/empty_payload/bulk
-	icon_state = "woodworking"
-	steps = list(
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASTEEL, "time" = 1),
-		list(QUALITY_WELDING, 35, "time" = 5),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 1),
-		list(QUALITY_CUTTING, 35, "time" = 5)
-	)
-
-//Armor mods ----------------------
+//Shields and Armor Mods | Gonna be expanded on later
 /datum/craft_recipe/pirs/melee
 	name = "melee plating"
 	result = /obj/item/tool_upgrade/armor/melee
@@ -83,111 +70,6 @@
 		list(QUALITY_SAWING, 30, "time" = 60)
 	)
 
-//Robot Armor ----------------------
-
-/datum/craft_recipe/pirs/robotmelee //Lots of steps
-	name = "robot mark v armor plating"
-	result = /obj/item/robot_parts/robot_component/armour/mkv
-	steps = list(
-		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 90),
-		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 30),
-		list(QUALITY_WELDING, 35, "time" = 90),
-		list(QUALITY_CUTTING, 30, "time" = 180),
-		list(QUALITY_HAMMERING, 30, "time" = 180),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 90),
-		list(QUALITY_BOLT_TURNING, 30, "time" = 120),
-		list(QUALITY_SAWING, 30, "time" = 60)
-	)
-
-//Tools --------------------------
-
-/datum/craft_recipe/pirs/combat_shovel
-	name = "combat crovel"
-	result = /obj/item/tool/shovel/combat
-	steps = list(
-		list(/obj/item/tool/shovel, 1),
-		list(QUALITY_SAWING, 20, "time" = 40),
-		list(QUALITY_HAMMERING, 30, "time" = 40),
-		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL, "time" = 60),
-		list(QUALITY_SCREW_DRIVING, 20, "time" = 30),
-		list(/obj/item/tool_upgrade/augment/spikes, 1),
-		list(QUALITY_BOLT_TURNING, 30, "time" = 10)
-	)
-
-//Weapons ------------------------
-/* Kept as reference. These are literally terrible LOL
-/datum/craft_recipe/pirs/nanopistol
-	name = "MKI Forger compressed-matter pistol"
-	result = /obj/item/gun/projectile/matter_gun
-	steps = list(
-		list(CRAFT_MATERIAL, 15, MATERIAL_PLASTEEL, "time" = 15),
-		list(QUALITY_CUTTING, 30, "time" = 10),
-		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTIC, "time" = 15),
-		list(QUALITY_BOLT_TURNING, 30, "time" = 20),
-		list(/obj/item/cell/medium, 1, "time" = 5),
-		list(/obj/item/computer_hardware/tesla_link, 1, "time" = 10),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
-		list(/obj/item/stack/cable_coil, 10, "time" = 15),
-		list(QUALITY_WIRE_CUTTING, 40, "time" = 15),
-		list(/obj/item/stock_parts/manipulator/nano, 1, "time" = 15),
-		list(/obj/item/stock_parts/matter_bin/adv, 1, "time" = 5),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
-	)
-
-/datum/craft_recipe/pirs/nanoshotgun
-	name = "MKII Forger compressed-matter shotgun"
-	result = /obj/item/gun/projectile/matter_gun/shotgun
-	steps = list(
-		list(/obj/item/gun/projectile/matter_gun, 1, "time" = 15),
-		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 15),
-		list(QUALITY_CUTTING, 30, "time" = 10),
-		list(CRAFT_MATERIAL, 12, MATERIAL_PLASTIC, "time" = 15),
-		list(QUALITY_BOLT_TURNING, 30, "time" = 20),
-		list(/obj/item/cell/large, 1, "time" = 5),
-		list(/obj/item/computer_hardware/tesla_link, 1, "time" = 10),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
-		list(/obj/item/stack/cable_coil, 20, "time" = 15),
-		list(QUALITY_WIRE_CUTTING, 40, "time" = 15),
-		list(/obj/item/stock_parts/capacitor/handmade, 1, "time" = 10),
-		list(/obj/item/stock_parts/micro_laser/handmade, 1, "time" = 10),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
-	)
-*/
-/* Kept for reference for now. Replacement soon (tm)
-//An exspensive but powerful CQC weapon that also can be used as a flar gun
-/datum/craft_recipe/pirs/abdicatorshotgun
-	name ="abdicator energy shotgun"
-	result = /obj/item/gun/energy/laser/railgun/abdicator
-	steps = list(
-		list(CRAFT_MATERIAL, 20, MATERIAL_PLASTEEL, "time" = 15),
-		list(QUALITY_CUTTING, 30, "time" = 10),
-		list(CRAFT_MATERIAL, 4, MATERIAL_PLASMA, "time" = 15),
-		list(QUALITY_BOLT_TURNING, 30, "time" = 20),
-		list(QUALITY_HAMMERING, 10, "time" = 20),
-		list(/obj/item/stock_parts/smes_coil, 1, "time" = 5),
-		list(QUALITY_WELDING, 35, "time" = 15),
-		list(/obj/item/cell/large, 1, "time" = 5),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
-		list(/obj/item/stack/cable_coil, 30, "time" = 15),
-		list(QUALITY_WIRE_CUTTING, 40, "time" = 15),
-		list(/obj/item/stock_parts/subspace/ansible, 1, "time" = 1),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
-		list(CRAFT_MATERIAL, 10, MATERIAL_WOOD, "time" = 20),
-		list(QUALITY_HAMMERING, 30, "time" = 20),
-		list(CRAFT_MATERIAL, 6, MATERIAL_RGLASS, "time" = 10),
-		list(/obj/item/stock_parts/capacitor/adv, 1, "time" = 10),
-		list(/obj/item/stock_parts/micro_laser/high, 1, "time" = 10),
-		list(/obj/item/computer_hardware/tesla_link, 1, "time" = 10),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS, "time" = 20),
-		list(CRAFT_MATERIAL, 1, MATERIAL_URANIUM, "time" = 20),
-		list(QUALITY_HAMMERING, 40, "time" = 30),
-		list(CRAFT_MATERIAL, 15, MATERIAL_PLASTIC, "time" = 20),
-		list(CRAFT_MATERIAL, 4, MATERIAL_STEEL, "time" = 5),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 5)
-	)
-*/
-
 /datum/craft_recipe/pirs/bastion
 	name = "Bastion Shield"
 	result = /obj/item/shield/riot/bastion
@@ -200,47 +82,6 @@
 	list(QUALITY_HAMMERING, 45, "time" = 40),
 	list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS, "time" = 30)
 	)
-
-
-//Wearables =========================
-
-/datum/craft_recipe/pirs/sheet_stacker
-	name = "advanced sheet snatcher"
-	icon_state = "woodworking"
-	result = /obj/item/storage/bag/sheetsnatcher/guild
-	steps = list(
-		list(CRAFT_MATERIAL, 10, MATERIAL_WOOD, "time" = 30),
-		list(QUALITY_SCREW_DRIVING, 35, "time" = 20),
-		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL, "time" = 60),
-		list(QUALITY_ADHESIVE, 10, "time" = 60),
-		list(/obj/item/stack/cable_coil, 30, "time" = 30),
-		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
-	)
-
-//Tool/Gun Mods ---------------------
-//Reinforcement
-
-/datum/craft_recipe/pirs/rubbermesh
-	name = "Rubber Mesh"
-	result = /obj/item/tool_upgrade/reinforcement/rubbermesh
-	steps = list(
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC, "time" = 30),
-		list(QUALITY_WIRE_CUTTING, 20, "time" = 90)
-	)
-
-//Productivity
-/datum/craft_recipe/pirs/booster
-	name = "Booster"
-	result = /obj/item/tool_upgrade/productivity/booster
-	steps = list(
-		list(CRAFT_MATERIAL, 3, MATERIAL_STEEL, "time" = 30),
-		list(QUALITY_HAMMERING, 30, "time" = 40),
-		list(CRAFT_MATERIAL, 2, MATERIAL_PLASTIC, "time" = 30),
-		list(QUALITY_SCREW_DRIVING, 25, "time" = 90),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD, "time" = 30),
-		list(QUALITY_BOLT_TURNING, 20, "time" = 40)
-	)
-
 //Gun Mods
 /datum/craft_recipe/pirs/weintraub
 	name = "\"Hurricane\" full auto kit"
@@ -255,7 +96,6 @@
 		list(QUALITY_SCREW_DRIVING, 25, "time" = 90)
 	)
 
-//Gun Mods
 /datum/craft_recipe/pirs/overshooter
 	name = "\"Overshooter\" internal magazine kit"
 	result = /obj/item/gun_upgrade/mechanism/overshooter
@@ -340,51 +180,8 @@
 		list(CRAFT_MATERIAL, 2, MATERIAL_GLASS, "time" = 30),
 		list(QUALITY_CUTTING, 25, "time" = 90)
 	)
-/*
-//Traps
-/datum/craft_recipe/pirs/guild_mine_trap
-	name = "land mine trap"
-	result = /obj/item/mine
-	icon_state = "gun"
-	steps = list(
-		list(/obj/item/mine/improvised, 1, "time" = 120),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(CRAFT_MATERIAL, 20, MATERIAL_STEEL),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(/obj/item/stack/cable_coil, 2, "time" = 10)
-	)*/
-//Machines & Mechs
 
-/datum/craft_recipe/pirs/safety_clamp
-	name = "Hydraulic clamp overclock: KILL CLAMP"
-	result = /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
-	steps = list(
-		list(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp, 1, "time" = 60),
-		list(QUALITY_BOLT_TURNING, 30, "time" = 40),
-		list(/obj/item/tool_upgrade/productivity/motor, 1, "time" = 60),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(/obj/item/tool_upgrade/augment/hydraulic, 1, "time" = 60),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL),
-		list(QUALITY_WELDING, 30, "time" = 40),
-		list(/obj/item/tool_upgrade/augment/spikes, 1, "time" = 60)
-	)
-
-/datum/craft_recipe/pirs/tesla_energy_relay
-	name = "Mech energy relay"
-	result = /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
-	steps = list(
-		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 30),
-		list(QUALITY_WELDING, 45, "time" = 40),
-		list(QUALITY_BOLT_TURNING, 30, 70),
-		list(/obj/item/computer_hardware/tesla_link, 2, "time" = 60),
-		list(QUALITY_SCREW_DRIVING, 35, 70),
-		list(/obj/item/stack/cable_coil, 15, "time" = 90),
-		list(QUALITY_WIRE_CUTTING, 25, "time" = 90),
-		list(/obj/item/stock_parts/capacitor/super, 1, "time" = 60),
-		list(QUALITY_SCREW_DRIVING, 10, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_GOLD)
-	)
+//STOCK PARTS | PIRS and Union can both craft T3 and T4, but PIRS gets the bulk T4 craft.
 
 /datum/craft_recipe/pirs/guild_bin
 	name = "Hand Giga Matter Bin"
@@ -453,62 +250,7 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_SILVER),
 		list(QUALITY_SAWING, 30)
 	)
-/*
-/datum/craft_recipe/pirs/guild_manip_alt
-	name = "Forged Manipulator Alt"
-	result = /obj/item/stock_parts/manipulator/handmade
-	steps = list(
-		list(/obj/item/stock_parts/manipulator/nano, 2),
-		list(QUALITY_SCREW_DRIVING, 35, 70),
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTEEL),
-		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 35),
-		list(/obj/item/stack/cable_coil, 10),
-		list(QUALITY_HAMMERING, 40),
-		list(QUALITY_SAWING, 60)
-	)
 
-/datum/craft_recipe/pirs/guild_laser_alt
-	name = "Perfected Micro-Laser Alt"
-	result = /obj/item/stock_parts/micro_laser/handmade
-	steps = list(
-		list(/obj/item/stock_parts/micro_laser/high, 2),
-		list(QUALITY_SCREW_DRIVING, 35, 70),
-		list(CRAFT_MATERIAL, 1, MATERIAL_PLASMAGLASS),
-		list(CRAFT_MATERIAL, 1, MATERIAL_RGLASS),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 35),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/pirs/guild_scanner_alt
-	name = "Perfected Scanning Module Alt"
-	result = /obj/item/stock_parts/scanning_module/handmade
-	steps = list(
-		list(/obj/item/stock_parts/scanning_module/adv, 2),
-		list(QUALITY_SCREW_DRIVING, 35, 70),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 35),
-		list(CRAFT_MATERIAL, 2, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60)
-	)
-
-/datum/craft_recipe/pirs/guild_capacitor_alt
-	name = "Crafted Ultra Capacitor Alt"
-	result = /obj/item/stock_parts/capacitor/handmade
-	steps = list(
-		list(/obj/item/stock_parts/capacitor/adv, 2),
-		list(QUALITY_SCREW_DRIVING, 35, 70),
-		list(CRAFT_MATERIAL, 2, MATERIAL_GOLD),
-		list(QUALITY_BOLT_TURNING, 10, 70),
-		list(QUALITY_WELDING, 35),
-		list(CRAFT_MATERIAL, 2, MATERIAL_SILVER),
-		list(QUALITY_SAWING, 60)
-	)
-*/
-// Fixes a matdupe here. Please ensure these are never cheaper to make than anything else.
 /datum/craft_recipe/pirs/guild_bin_box
 	name = "Box of Giga Matter Bins"
 	result = /obj/item/storage/box/guild_bin

--- a/code/datums/craft/recipes/pirs.dm
+++ b/code/datums/craft/recipes/pirs.dm
@@ -183,7 +183,7 @@
 
 //STOCK PARTS | PIRS and Union can both craft T3 and T4, but PIRS gets the bulk T4 craft.
 
-/datum/craft_recipe/pirs/guild_bin
+/datum/craft_recipe/pirs/handmade_bin
 	name = "Hand Giga Matter Bin"
 	result = /obj/item/stock_parts/matter_bin/handmade
 	steps = list(
@@ -197,7 +197,7 @@
 		list(QUALITY_SAWING, 30)
 	)
 
-/datum/craft_recipe/pirs/guild_manip
+/datum/craft_recipe/pirs/handmade_manip
 	name = "Perfected Flexi-Pico Manipulator"
 	result = /obj/item/stock_parts/manipulator/handmade
 	steps = list(
@@ -212,7 +212,7 @@
 		list(QUALITY_SAWING, 30)
 	)
 
-/datum/craft_recipe/pirs/guild_laser
+/datum/craft_recipe/pirs/handmade_laser
 	name = "Handmade Perfected Ultra High Power Micro-Lasers"
 	result = /obj/item/stock_parts/micro_laser/handmade
 	steps = list(
@@ -225,7 +225,7 @@
 		list(QUALITY_SAWING, 30)
 	)
 
-/datum/craft_recipe/pirs/guild_scanner
+/datum/craft_recipe/pirs/handmade_scanner
 	name = "Overtuned Scanning Module"
 	result = /obj/item/stock_parts/scanning_module/handmade
 	steps = list(
@@ -238,7 +238,7 @@
 		list(QUALITY_SAWING, 30)
 	)
 
-/datum/craft_recipe/pirs/guild_capacitor
+/datum/craft_recipe/pirs/handmade_capacitor
 	name = "Crafted Experimental Capacitor"
 	result = /obj/item/stock_parts/capacitor/handmade
 	steps = list(
@@ -251,9 +251,9 @@
 		list(QUALITY_SAWING, 30)
 	)
 
-/datum/craft_recipe/pirs/guild_bin_box
+/datum/craft_recipe/pirs/handmade_bin_box
 	name = "Box of Giga Matter Bins"
-	result = /obj/item/storage/box/guild_bin
+	result = /obj/item/storage/box/handmade_bin
 	steps = list(
 		list(/obj/item/stock_parts/matter_bin/super, 4),
 		list(QUALITY_SCREW_DRIVING, 10, 70),
@@ -266,9 +266,9 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
 	)
 
-/datum/craft_recipe/pirs/guild_manip_box
+/datum/craft_recipe/pirs/handmade_manip_box
 	name = "Box of Flexi-Pico Manipulators"
-	result = /obj/item/storage/box/guild_manip
+	result = /obj/item/storage/box/handmade_manip
 	steps = list(
 		list(/obj/item/stock_parts/manipulator/pico, 4),
 		list(QUALITY_SCREW_DRIVING, 35, 70),
@@ -282,9 +282,9 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
 	)
 
-/datum/craft_recipe/pirs/guild_laser_box
+/datum/craft_recipe/pirs/handmade_laser_box
 	name = "Box of Perfected Ultra High Power Micro-Lasers"
-	result = /obj/item/storage/box/guild_laser
+	result = /obj/item/storage/box/handmade_laser
 	steps = list(
 		list(/obj/item/stock_parts/micro_laser/ultra, 4),
 		list(QUALITY_SCREW_DRIVING, 35, 70),
@@ -296,9 +296,9 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
 	)
 
-/datum/craft_recipe/pirs/guild_scanner_box
+/datum/craft_recipe/pirs/handmade_scanner_box
 	name = "Box of Over-Tuned Scanning Modules"
-	result = /obj/item/storage/box/guild_scanner
+	result = /obj/item/storage/box/handmade_scanner
 	steps = list(
 		list(/obj/item/stock_parts/scanning_module/phasic, 4),
 		list(QUALITY_SCREW_DRIVING, 35, 70),
@@ -310,9 +310,9 @@
 		list(CRAFT_MATERIAL, 1, MATERIAL_CARDBOARD)
 	)
 
-/datum/craft_recipe/pirs/guild_capacitor_box
+/datum/craft_recipe/pirs/handmade_capacitor_box
 	name = "Box of Crafted Experimental Capacitors"
-	result = /obj/item/storage/box/guild_capacitor
+	result = /obj/item/storage/box/handmade_capacitor
 	steps = list(
 		list(/obj/item/stock_parts/capacitor/super, 4),
 		list(QUALITY_SCREW_DRIVING, 35, 70),

--- a/code/datums/craft/recipes/robot.dm
+++ b/code/datums/craft/recipes/robot.dm
@@ -179,7 +179,7 @@
 	)
 
 //copypasted from PIRS craft code to here, Union can have it too
-/datum/craft_recipe/pirs/safety_clamp
+/datum/craft_recipe/robotic/safety_clamp
 	name = "Hydraulic clamp overclock: KILL CLAMP"
 	result = /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
 	steps = list(
@@ -194,7 +194,7 @@
 		list(/obj/item/tool_upgrade/augment/spikes, 1, "time" = 60)
 	)
 
-/datum/craft_recipe/pirs/robotmelee //Lots of steps
+/datum/craft_recipe/robotic/robotmelee //Lots of steps
 	name = "robot mark v armor plating"
 	result = /obj/item/robot_parts/robot_component/armour/mkv
 	steps = list(

--- a/code/datums/craft/recipes/robot.dm
+++ b/code/datums/craft/recipes/robot.dm
@@ -177,3 +177,33 @@
 		list(QUALITY_BOLT_TURNING, 10, "time" = 180),
 		list(QUALITY_SCREW_DRIVING, 10, "time" = 90)
 	)
+
+//copypasted from PIRS craft code to here, Union can have it too
+/datum/craft_recipe/pirs/safety_clamp
+	name = "Hydraulic clamp overclock: KILL CLAMP"
+	result = /obj/item/mecha_parts/mecha_equipment/tool/safety_clamp
+	steps = list(
+		list(/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp, 1, "time" = 60),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 40),
+		list(/obj/item/tool_upgrade/productivity/motor, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(/obj/item/tool_upgrade/augment/hydraulic, 1, "time" = 60),
+		list(QUALITY_SCREW_DRIVING, 10, 70),
+		list(CRAFT_MATERIAL, 6, MATERIAL_PLASTEEL),
+		list(QUALITY_WELDING, 30, "time" = 40),
+		list(/obj/item/tool_upgrade/augment/spikes, 1, "time" = 60)
+	)
+
+/datum/craft_recipe/pirs/robotmelee //Lots of steps
+	name = "robot mark v armor plating"
+	result = /obj/item/robot_parts/robot_component/armour/mkv
+	steps = list(
+		list(CRAFT_MATERIAL, 10, MATERIAL_PLASTEEL, "time" = 90),
+		list(CRAFT_MATERIAL, 10, MATERIAL_STEEL, "time" = 30),
+		list(QUALITY_WELDING, 35, "time" = 90),
+		list(QUALITY_CUTTING, 30, "time" = 180),
+		list(QUALITY_HAMMERING, 30, "time" = 180),
+		list(QUALITY_SCREW_DRIVING, 35, "time" = 90),
+		list(QUALITY_BOLT_TURNING, 30, "time" = 120),
+		list(QUALITY_SAWING, 30, "time" = 60)
+	)

--- a/code/datums/craft/recipes/tools.dm
+++ b/code/datums/craft/recipes/tools.dm
@@ -162,7 +162,7 @@
 		list(QUALITY_WIRE_CUTTING, 10, 20),
 		list(/obj/item/stack/rods, 2, 30)
 	)
-	
+
 /datum/craft_recipe/tool/improv_charger
 	name = "improvised crank charger"
 	result = /obj/item/device/manual_charger/improv
@@ -276,4 +276,12 @@
 			list(CRAFT_MATERIAL, 1, MATERIAL_STEEL),
 			list(QUALITY_WIRE_CUTTING, 10, 50),
 			list(/obj/item/stack/wax, 4, 4)
+	)
+//A rubber mesh to defend the sensitive bits
+/datum/craft_recipe/pirs/rubbermesh
+	name = "Rubber Mesh"
+	result = /obj/item/tool_upgrade/reinforcement/rubbermesh
+	steps = list(
+		list(CRAFT_MATERIAL, 3, MATERIAL_PLASTIC, "time" = 30),
+		list(QUALITY_WIRE_CUTTING, 20, "time" = 90)
 	)

--- a/code/datums/craft/recipes/tools.dm
+++ b/code/datums/craft/recipes/tools.dm
@@ -278,7 +278,7 @@
 			list(/obj/item/stack/wax, 4, 4)
 	)
 //A rubber mesh to defend the sensitive bits
-/datum/craft_recipe/pirs/rubbermesh
+/datum/craft_recipe/tool/rubbermesh
 	name = "Rubber Mesh"
 	result = /obj/item/tool_upgrade/reinforcement/rubbermesh
 	steps = list(

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -35,7 +35,7 @@
 		STAT_COG = 25
 	)
 
-	perks = list(PERK_MEDICAL_EXPERT, PERK_ADVANCED_MEDICAL, PERK_SCIENCE, PERK_CHEMIST)
+	perks = list(PERK_MEDICAL_EXPERT, PERK_ADVANCED_MEDICAL, PERK_CHEMIST)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/suit_sensors,

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -742,54 +742,54 @@
 /obj/item/storage/box/data_disk/basic/empty/populate_contents()
 	return
 
-// Guild boxes, exclusively used to mass craft guild parts.
-/obj/item/storage/box/guild_manip
+// handmade boxes, exclusively used to mass craft handmade parts.
+/obj/item/storage/box/handmade_manip
 	name = "box of forged manipulators"
-	desc = "A box containing five forged manipulators, the best that Liberty can produce."
+	desc = "A box containing forged manipulators, the best that Liberty can produce."
 	icon_state = "box_of_doom"
 	illustration = "guild"
 
-/obj/item/storage/box/guild_manip/populate_contents()
+/obj/item/storage/box/handmade_manip/populate_contents()
 	for(var/i in 1 to 4)
 		new /obj/item/stock_parts/manipulator/handmade(src)
 
-/obj/item/storage/box/guild_bin
+/obj/item/storage/box/handmade_bin
 	name = "box of cast matter bins"
-	desc = "A box containing five cast matter bins, the best that Liberty can produce."
+	desc = "A box containing cast matter bins, the best that Liberty can produce."
 	icon_state = "box_of_doom"
 	illustration = "guild"
 
-/obj/item/storage/box/guild_bin/populate_contents()
+/obj/item/storage/box/handmade_bin/populate_contents()
 	for(var/i in 1 to 4)
 		new /obj/item/stock_parts/matter_bin/handmade(src)
 
-/obj/item/storage/box/guild_laser
+/obj/item/storage/box/handmade_laser
 	name = "box of perfected micro-lasers"
-	desc = "A box containing five perfected micro-lasers, the best that Liberty can produce."
+	desc = "A box containing perfected micro-lasers, the best that Liberty can produce."
 	icon_state = "box_of_doom"
 	illustration = "guild"
 
-/obj/item/storage/box/guild_laser/populate_contents()
+/obj/item/storage/box/handmade_laser/populate_contents()
 	for(var/i in 1 to 4)
 		new /obj/item/stock_parts/micro_laser/handmade(src)
 
-/obj/item/storage/box/guild_scanner
+/obj/item/storage/box/handmade_scanner
 	name = "box of perfected scanning modules"
-	desc = "A box containing five perfected scanning modules, the best that Liberty can produce."
+	desc = "A box containing perfected scanning modules, the best that Liberty can produce."
 	icon_state = "box_of_doom"
 	illustration = "guild"
 
-/obj/item/storage/box/guild_scanner/populate_contents()
+/obj/item/storage/box/handmade_scanner/populate_contents()
 	for(var/i in 1 to 4)
 		new /obj/item/stock_parts/scanning_module/handmade(src)
 
-/obj/item/storage/box/guild_capacitor
+/obj/item/storage/box/handmade_capacitor
 	name = "box of ultra capacitors"
-	desc = "A box containing five ultra capacitors, the best that Liberty can produce."
+	desc = "A box containing ultra capacitors, the best that Liberty can produce."
 	icon_state = "box_of_doom"
 	illustration = "guild"
 
-/obj/item/storage/box/guild_capacitor/populate_contents()
+/obj/item/storage/box/handmade_capacitor/populate_contents()
 	for(var/i in 1 to 4)
 		new /obj/item/stock_parts/capacitor/handmade(src)
 

--- a/code/modules/research/nodes/engineering.dm
+++ b/code/modules/research/nodes/engineering.dm
@@ -266,7 +266,7 @@
 							/datum/design/research/item/weapon/toolmod/plating,
 							/datum/design/research/item/weapon/toolmod/guard,
 							/datum/design/research/item/weapon/toolmod/plasmablock,
-							/datum/design/research/item/weapon/toolmod/rubbermesh
+							//datum/design/research/item/weapon/toolmod/rubbermesh
 							)
 
 /datum/technology/productivity_toolmods

--- a/code/modules/research/nodes/engineering.dm
+++ b/code/modules/research/nodes/engineering.dm
@@ -265,8 +265,8 @@
 							/datum/design/research/item/weapon/toolmod/heatsink,
 							/datum/design/research/item/weapon/toolmod/plating,
 							/datum/design/research/item/weapon/toolmod/guard,
-							//datum/design/research/item/weapon/toolmod/plasmablock,
-							//datum/design/research/item/weapon/toolmod/rubbermesh
+							/datum/design/research/item/weapon/toolmod/plasmablock,
+							/datum/design/research/item/weapon/toolmod/rubbermesh
 							)
 
 /datum/technology/productivity_toolmods
@@ -290,8 +290,8 @@
 							/datum/design/research/item/weapon/toolmod/oxyjet,
 							/datum/design/research/item/weapon/toolmod/motor,
 							/datum/design/research/item/weapon/toolmod/antistaining,
-							//datum/design/research/item/weapon/toolmod/booster,
-							//datum/design/research/item/weapon/toolmod/injector
+							/datum/design/research/item/weapon/toolmod/booster,
+							/datum/design/research/item/weapon/toolmod/injector
 							)
 
 /datum/technology/refinement_toolmods


### PR DESCRIPTION
Tweaked PR #388 to be a lot more fair and lore friendly to both PIRS and TT-Union
## Changelog
:cl:
balance: Moved exosuit and borg augments originally inside the PIRS general craft to the Robotics tab.
balance: Added back T4 craft for Union, but they can't make the bulk recipe to create redundancy  
tweak: Made the following items unrestricted crafts (let me know if they're duplicated somewhere): payload arrow, rubber mesh
tweak: Returned the Booster, Injector, Plasma Block, and Rubber Mesh to PIRS Protolathe, given they're going to be the faction you go to for Tool/Gun/Armor mods with the armor mods system expanded in the future
del: Tool related things from PIRS craft, as tools are Union's thing
del: Tesla relay recipe, as it skips intended research progression and it's cheaper if you research it anyways
By Trilby
Removes t3 parts from being hand crafted by terra
Renames guild_ to handmade_
Removes CSO science perk
Removes the skylight omni tool from terra crafting
/:cl:

Let me know if I missed anything, I can tweak it some more. Generally, I think these changes will be an olive branch for Union players and be the start of proper content updates for PIRS.