### PR TITLE
precursor PIRS prep

### DIFF
--- a/maps/_dungeons/precursor/precursor.dmm
+++ b/maps/_dungeons/precursor/precursor.dmm
@@ -261,6 +261,7 @@
 /area/precursor/mini_base)
 "AG" = (
 /obj/map_data/precursor,
+/obj/marker/precursor,
 /turf/unsimulated/mineral,
 /area/precursor)
 "BH" = (

--- a/maps/submaps/precursor_rooms/normal/hydro.dmm
+++ b/maps/submaps/precursor_rooms/normal/hydro.dmm
@@ -151,10 +151,6 @@
 /obj/structure/low_wall/rusted,
 /turf/simulated/floor/snow,
 /area/precursor)
-"X" = (
-/obj/structure/low_wall/rusted,
-/turf/space,
-/area/precursor)
 "Y" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/structure/low_wall/rusted,
@@ -192,7 +188,7 @@ a
 "}
 (3,1,1) = {"
 e
-X
+T
 e
 l
 Y


### PR DESCRIPTION
Preps precursor dungeon code for the machine to be placed in PIRS
Creates new marker for the precursor map. Helps code of the precursor device find the dungeon z level.
Fixes a space tile in the dungeon generation that would empty the air out of most of the dungeon.