### PR TITLE
Custodian Fax Rename

### DIFF
--- a/maps/__Liberty/data/_Liberty_factions.dm
+++ b/maps/__Liberty/data/_Liberty_factions.dm
@@ -91,7 +91,7 @@
 	stampshape = "paper_stamp-dots"
 
 /datum/faction/liberty/church
-	name = "Bonfire Custodians - Liekki Korhonen"
+	name = "Custodian Colonial Upper Assemblage"
 
 	fax_alert = "CHURCH FAX"
 	fax_response = "Church Decree"
@@ -100,7 +100,7 @@
 	darkcolor = "#051d66"
 	lightcolor = "#5b83ff"
 
-	stamptext = "This paper has been stamped with the sanctified symbol of Spark Liekki Korhonen."
+	stamptext = "This paper has been stamped with the sanctified symbol of Higher Custodian Assemblage."
 	stampshape = "paper_stamp-dots"
 
 /datum/faction/liberty/voidwolves

--- a/maps/__Liberty/data/_Liberty_factions.dm
+++ b/maps/__Liberty/data/_Liberty_factions.dm
@@ -91,7 +91,7 @@
 	stampshape = "paper_stamp-dots"
 
 /datum/faction/liberty/church
-	name = "Bonfire Custodians"
+	name = "Bonfire Custodians - Liekki Korhonen"
 
 	fax_alert = "CHURCH FAX"
 	fax_response = "Church Decree"

--- a/maps/__Liberty/data/_Liberty_factions.dm
+++ b/maps/__Liberty/data/_Liberty_factions.dm
@@ -91,7 +91,7 @@
 	stampshape = "paper_stamp-dots"
 
 /datum/faction/liberty/church
-	name = "Church of Bonfire - Augstine Browne"
+	name = "Bonfire Custodians"
 
 	fax_alert = "CHURCH FAX"
 	fax_response = "Church Decree"
@@ -100,7 +100,7 @@
 	darkcolor = "#051d66"
 	lightcolor = "#5b83ff"
 
-	stamptext = "This paper has been stamped with the sanctified symbol of Cartographer Augustine Browne."
+	stamptext = "This paper has been stamped with the sanctified symbol of Spark Liekki Korhonen."
 	stampshape = "paper_stamp-dots"
 
 /datum/faction/liberty/voidwolves


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	The following PR just renames the old Augustine Browne fax tooltip to Spark Liekki Korhonen. Nothing major.
</summary>
<hr>
	
<hr>
</details>

## Changelog
:cl:
tweak: Fixes the fax machine to have the right name.
/:cl:
