### PR TITLE
Even more bugfixes

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -174,7 +174,7 @@
 	return // No removing the cell out of these ones for a free Simulacrum cell
 	// Also not unwrenching or wrenching either for free infinite light anywhere.
 
-/obj/machinery/floodlight/update_icon()
+/obj/machinery/floodlight/gate/update_icon()
 	cut_overlays()
 	icon_state = "gate0[on]"
 

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -54,7 +54,7 @@
 					var/obj/item/stack/material/steel/MM = new (get_turf(src))
 					MM.amount = m
 					user.visible_message(
-						SPAN_NOTICE("[user] removes [m] sheet\s of metal from the \the [src]."),
+						SPAN_NOTICE("[user] removes [m] sheet\s of metal from \the [src]."),
 						SPAN_NOTICE("You remove [m] sheet\s of metal from \the [src]"))
 			else
 				to_chat(user, "\The [src] is empty.")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -2223,7 +2223,7 @@ assassination method if you time it right*/
 	if(!deflect_hit(is_melee=1))
 		src.hit_damage(damage, is_melee=1)
 		src.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
-		visible_message(SPAN_DANGER("[user] [attack_message] [src]!"))
+		visible_message(SPAN_DANGER("\The [user] has [attack_message] \the [src]!"))
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name]</font>")
 	else
 		src.log_append_to_last("Armor saved.")

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -224,7 +224,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 /obj/item/clothing/mask/smokable/attack(var/mob/living/M, var/mob/living/user, def_zone)
 	if(istype(M) && M.on_fire)
 		user.do_attack_animation(M)
-		light(SPAN_NOTICE("\The [user] coldly lights the \the [src] with the burning body of \the [M]."))
+		light(SPAN_NOTICE("\The [user] coldly lights \the [src] with the burning body of \the [M]."))
 		return 1
 	else
 		return ..()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -65,7 +65,7 @@
 /obj/item/shield/attackby(obj/item/I, mob/user)
 	if(I.has_quality(QUALITY_ADHESIVE))
 		if(src.durability)
-			user.visible_message(SPAN_NOTICE("[user] begins repairing \the [src] with the [I]!"))
+			user.visible_message(SPAN_NOTICE("[user] begins repairing \the [src] with \the [I]!"))
 			if(I.use_tool(user, src, WORKTIME_NORMAL, QUALITY_ADHESIVE, FAILCHANCE_EASY, required_stat = STAT_MEC))
 				src.adjustShieldDurability(src.max_durability * 0.8 + (user.stats.getStat(STAT_MEC)*0.2)*0.1, user)
 
@@ -83,11 +83,11 @@
 		else if (durability > max_durability * 0.20)
 			to_chat(user, SPAN_WARNING("It looks a bit cracked and worn."))
 		else if (durability > max_durability * 0.10)
-			to_chat(user, SPAN_WARNING("Whatever use this tool once had is fading fast."))
+			to_chat(user, SPAN_WARNING("It is lined up with cuts and badly bent."))
 		else if (durability > max_durability * 0.05)
-			to_chat(user, SPAN_WARNING("Attempting to use this thing as a tool is probably not going to work out well."))
+			to_chat(user, SPAN_WARNING("Attempting to use this mangled thing to block is probably going to be a bad idea."))
 		else
-			to_chat(user, SPAN_DANGER("It's falling apart. This is one slip away from just being a pile of assorted trash."))
+			to_chat(user, SPAN_DANGER("It's falling apart. Attempting to block with this is guaranteed to have it crumble in your hands."))
 
 /obj/item/shield/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 
@@ -115,11 +115,11 @@
 				else
 					adjustShieldDurability(-damage_received)
 				defender.adjustHalLoss(damage_received)
-				defender.visible_message(SPAN_DANGER("\The [defender] blocks [attack_text] with \the [src]!"))
+				defender.visible_message(SPAN_DANGER("\The [user] prevented being [attack_text] by blocking with \the [src]!"))
 				return 1
 	if(check_parry_arc(user, bad_arc, damage_source, attacker))
 		if(prob(get_block_chance(user, damage, damage_source, attacker)))
-			user.visible_message(SPAN_DANGER("\The [user] blocks [attack_text] with \the [src]!"))
+			user.visible_message(SPAN_DANGER("\The [user] prevented being [attack_text] by blocking with \the [src]!"))
 			return 1
 	return 0
 

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -7,7 +7,7 @@
 	var/list/allowed = list(/obj/item/clothing/suit/storage/toggle/labcoat, /obj/item/clothing/suit/storage/rank/insp_trench)
 
 /obj/structure/coatrack/attack_hand(mob/user as mob)
-	user.visible_message("[user] takes [coat] off \the [src].", "You take [coat] off the \the [src]")
+	user.visible_message("[user] takes [coat] off \the [src].", "You take \the [coat] off \the [src]")
 	if(!user.put_in_active_hand(coat))
 		coat.loc = get_turf(user)
 	coat = null
@@ -19,7 +19,7 @@
 		if(istype(W,T))
 			can_hang = 1
 	if (can_hang && !coat)
-		user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on the \the [src]")
+		user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on \the [src]")
 		coat = W
 		user.drop_from_inventory(coat, src)
 		update_icon()

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -633,12 +633,12 @@
 	if(damage)
 		damage(damage)
 		attack_animation(user)
-		visible_message(SPAN_DANGER("[user] [attack_message] the [src]!"))
+		visible_message(SPAN_DANGER("\The [user] has [attack_message] \the [src]!"))
 		return 1
 	if(!damage || !wallbreaker)
 		return
 	attack_animation(user)
-	visible_message(SPAN_DANGER("[user] [attack_message] the [src]!"))
+	visible_message(SPAN_DANGER("\The [user] has [attack_message] \the [src]!"))
 	dump_contents()
 	spawn(1) qdel(src)
 	return 1

--- a/code/game/supplyshuttle.dm
+++ b/code/game/supplyshuttle.dm
@@ -50,7 +50,7 @@ var/list/mechtoys = list(
 	if(damage)
 		damage(damage)
 		attack_animation(user)
-		visible_message(SPAN_DANGER("[user] [attack_message] the [src]!"))
+		visible_message(SPAN_DANGER("\The [user] has [attack_message] \the [src]!"))
 		return 1
 
 /obj/structure/plasticflaps/attackby(obj/item/I, mob/user)

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -240,13 +240,15 @@ var/list/flooring_types
 		if(M.stats.getPerk(PERK_KLUTZ) || our_trippah.stats.getStat(STAT_VIG) <= 0) //Negative Vig just makes you faceslam hard. This is equal to rolling uneven number with 1 Hand/Eye Coordination. Klutz is self explanatory
 			if(prob(60 - our_trippah.stats.getStat(STAT_VIG)))
 				to_chat(our_trippah, SPAN_WARNING("Your poor motorics made you slam hard into the plating!"))
+				playsound(M, 'sound/effects/bang.ogg', 50, 1)
 				our_trippah.adjustBruteLoss(15)
 				our_trippah.trip(src, 6)
 				return
 		if(M.stats.getPerk(PERK_SURE_STEP))//You trip even with this perk if klutz or vig below 0
 			return
 		if(prob(50 - our_trippah.stats.getStat(STAT_VIG)) && M.slip(null, 6)) //50 VIG makes you unable to trip
-			to_chat(our_trippah, SPAN_WARNING("You gently slam into the plating!"))
+			to_chat(M, SPAN_WARNING("You gently slam into the plating!"))
+			playsound(M, 'sound/weapons/pinground.ogg', 50, 1)
 			our_trippah.adjustBruteLoss(5)
 			our_trippah.trip(src, 6)
 			return
@@ -272,7 +274,7 @@ var/list/flooring_types
 	space_smooth = SMOOTH_NONE
 	smooth_movable_atom = SMOOTH_NONE
 
-//Hull can upgrade to underplating
+//Hull can downgrade to underplating
 /decl/flooring/reinforced/plating/hull/can_build_floor(var/decl/flooring/newfloor)
 	return FALSE //Not allowed to build directly on hull, you must first remove it and then build on the underplating
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -236,7 +236,7 @@
 			Proj.damage_types[BRUTE] = round(Proj.damage_types[BRUTE] / 2 + Proj.damage_types[BRUTE] * ricochetchance / 200)
 			Proj.damage_types[BURN] = round(Proj.damage_types[BURN] / 2 + Proj.damage_types[BURN] * ricochetchance / 200)
 			if (!(Proj.testing))
-				visible_message("<span class='danger'>\The [Proj] ricochets from the surface of wall!</span>")
+				visible_message("<span class='danger'>\The [Proj] ricochets from the surface of the wall!</span>")
 			projectile_reflection(Proj)
 			take_damage(min(proj_damage - damagediff, 100))
 			if (!(Proj.testing))

--- a/code/modules/client/preference_setup/general/06_furry.dm
+++ b/code/modules/client/preference_setup/general/06_furry.dm
@@ -169,7 +169,7 @@ datum/preferences
 		var/new_marking = input(user, "Choose a marking to add:", CHARACTER_PREFERENCE_INPUT_TITLE, null) as null|anything in GLOB.body_marking_list - pref.body_markings
 		if(new_marking && CanUseTopic(user))
 			pref.body_markings[new_marking] = "#000000"
-			log_and_message_admins("[key_name(usr)] has picked a marking.") // So that admins can see who's crashing the server through sparkledogs.
+			log_and_message_admins("[key_name(usr)] has picked a new marking.") // So that admins can see who's crashing the server through sparkledogs.
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["marking"])
 		if(CanUseTopic(user))

--- a/code/modules/client/preference_setup/general/06_furry.dm
+++ b/code/modules/client/preference_setup/general/06_furry.dm
@@ -169,6 +169,7 @@ datum/preferences
 		var/new_marking = input(user, "Choose a marking to add:", CHARACTER_PREFERENCE_INPUT_TITLE, null) as null|anything in GLOB.body_marking_list - pref.body_markings
 		if(new_marking && CanUseTopic(user))
 			pref.body_markings[new_marking] = "#000000"
+			log_and_message_admins("[key_name(usr)] has picked a marking.") // So that admins can see who's crashing the server through sparkledogs.
 		return TOPIC_REFRESH_UPDATE_PREVIEW
 	if(href_list["marking"])
 		if(CanUseTopic(user))

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -21,7 +21,7 @@ GLOBAL_LIST_INIT(chameleon_blacklist, list(
 	/obj/item/clothing/under,
 	/obj/item/clothing/under/rank,
 	/obj/item/clothing/under/color,
-	/obj/item/clothing/accessory,
+	/obj/item/clothing/accessory/holster, // Lacks holster/sheath functionality
 	/obj/item/clothing/glasses/hud,
 	/obj/item/clothing/gloves/color,
 	/obj/item/clothing/head/armor,
@@ -32,7 +32,8 @@ GLOBAL_LIST_INIT(chameleon_blacklist, list(
 	/obj/item/clothing/suit/armor/laserproof,
 	/obj/item/clothing/suit/storage/vest,
 	/obj/item/clothing/suit/storage,
-	/obj/item/clothing/suit/storage/toggle))
+	/obj/item/clothing/suit/storage/toggle,
+	/obj/item/storage/sheath))
 
 
 GLOBAL_LIST_INIT(chameleon_key_to_path, list(
@@ -317,7 +318,29 @@ GLOBAL_LIST_INIT(chameleon_key_to_path, list(
 	icon_state = "bluetie"
 	item_state = "bluetie"
 	chameleon_type = "accessory"
-	
+
+/obj/item/clothing/accessory/chameleon/disguise(newtype, mob/user)
+	if(!user || user.incapacitated())
+		return
+
+	var/obj/item/clothing/accessory/copy = new newtype(null)
+
+	desc = copy.desc
+	name = copy.name
+	icon = copy.icon
+	icon_state = copy.icon_state
+	item_state = copy.item_state
+	inv_overlay = copy.inv_overlay // So that it changes once worn on the inventory HUD
+	mob_overlay = copy.mob_overlay // Needed for the overlay appearance on accesories
+	body_parts_covered = copy.body_parts_covered
+	flags_inv = copy.flags_inv
+	item_icons = copy.item_icons.Copy()
+	item_state_slots = copy.item_state_slots?.Copy()
+
+	update_wear_icon()
+
+	return copy
+
 /obj/item/gun/energy/chameleon
 	name = "\"Liberty\" pistol"
 	desc = "A hologram projector in the shape of a gun. There is a dial on the side to change the gun's disguise."

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -231,7 +231,7 @@
 // CAPSA
 /obj/item/clothing/mask/gas/capsa
 	name = "CAPSA gas mask"
-	desc = "A sterile, industrial gas mask designed to keep temperature stable, and block harmful gasses from its wearer.\
+	desc = "A sterile, industrial gas mask designed to keep temperature stable, and block harmful gasses from its wearer. \
 			The visor provides excellent visibility even in snowstorms."
 	icon_state = "headhunter" // Katana ZERO reference. - Seb
 	flags_inv = HIDEEYES|HIDEFACE // Doesn't hide ears as it doesn't cover them

--- a/code/modules/mob/living/bot/drillbot.dm
+++ b/code/modules/mob/living/bot/drillbot.dm
@@ -8,7 +8,7 @@
 	faction = "similacrum"
 	layer = MOB_LAYER
 	var/obj/item/loot
-	var/attacktext = "drills"
+	var/attacktext = "drilled" // For reference, these verbs should be worded in plusquamperfect as they will always be preceded by "has". E.g: "[attacker] has [attacktext] [target]" or "has blocked being [attack_verb] by [attacker]"
 	var/environment_smash = 1
 
 /mob/living/bot/miningonestar/UnarmedAttack(var/atom/A, var/proximity)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1428,7 +1428,7 @@ var/list/rank_prefix = list(\
 
 /mob/living/carbon/human/slip(var/slipped_on, stun_duration=8)
 	if((species.flags & NO_SLIP) || (shoes && (shoes.item_flags & NOSLIP)))
-		return 0
+		return FALSE
 	..(slipped_on,stun_duration)
 
 /mob/living/carbon/human/trip(tripped_on, stun_duration)

--- a/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
+++ b/code/modules/mob/living/carbon/superior_animal/psi_monsters/types/corrupted_beings.dm
@@ -12,7 +12,7 @@
 	melee_damage_upper = 30
 	emote_see = list("howls in a broken voice.", "wracks its claws against the ground.", "gnarls.")
 	turns_per_move = 3
-	attacktext = "carves"
+	attacktext = "carved"
 	faction = "daskvey"
 
 	colony_friend = FALSE
@@ -43,7 +43,7 @@
 	emote_see = list("looks left then right.", "breathes heavily.", "adjusts their armour.")
 	turns_per_move = 3
 	move_to_delay = 3
-	attacktext = "cuts into"
+	attacktext = "cutted into"
 	faction = "daskvey"
 
 	chameleon_skill = 255
@@ -85,7 +85,7 @@
 	emote_see = list("sighs deeply")
 	turns_per_move = 1
 	move_to_delay = 1
-	attacktext = "rends apart"
+	attacktext = "rended apart"
 
 	armor_penetration = 35
 
@@ -179,7 +179,7 @@
 	emote_see = list("looks left then right.", "breaths heavily.", "adjusts their armour.")
 	turns_per_move = 3
 	move_to_delay = 4
-	attacktext = "hacks"
+	attacktext = "hacked"
 
 
 	drop_items = list(/obj/item/tool/sword/cleaver/cult/deepmaints)
@@ -198,7 +198,7 @@
 	emote_see = list("looks left then right.", "breaths heavily.", "adjusts their armour.")
 	turns_per_move = 3
 	move_to_delay = 4
-	attacktext = "bashes"
+	attacktext = "bashed"
 
 	drop_items = list(/obj/item/gun/energy/plasma/cassad/cult/deepmaints)
 
@@ -223,7 +223,7 @@
 	emote_see = list("looks left then right.", "breaths heavily.", "adjusts their armour.")
 	turns_per_move = 3
 	move_to_delay = 4
-	attacktext = "bashes"
+	attacktext = "bashed"
 
 	viewRange = 20
 	comfy_range = 20
@@ -251,7 +251,7 @@
 	emote_see = list("looks left then right.", "breaths heavily.", "adjusts their armour.")
 	turns_per_move = 3
 	move_to_delay = 4
-	attacktext = "bashes"
+	attacktext = "bashed"
 
 	drop_items = list(/obj/item/gun/projectile/automatic/greasegun/cult/deepmaints)
 
@@ -284,7 +284,7 @@
 	emote_see = list("looks left then right.", "breaths heavily.", "adjusts their armour.")
 	turns_per_move = 3
 	move_to_delay = 4
-	attacktext = "bashes"
+	attacktext = "bashed"
 
 	drop_items = list(/obj/item/gun/projectile/automatic/sts/rifle/cult/deepmaints)
 
@@ -304,7 +304,7 @@
 	armor_penetration = 15
 
 /mob/living/carbon/superior_animal/psi_monster/daskvey_follower/shield
-	name = "Daskveyian Juggernaut "
+	name = "Daskveyian Juggernaut"
 	desc = "A soul of strength and integrity, recovered from the ravages laid upon it. Outfitted in heavy armor, it protects those in its shadow with unbending steel, for they are the wall that holds back any that seek to harm their kin."
 	icon_state = "psi_juggernaut_glass_Shield"
 	icon_living = "psi_juggernaut_glass_Shield"
@@ -315,7 +315,7 @@
 	emote_see = list("looks left then right.", "breaths heavily.", "adjusts their armour.")
 	turns_per_move = 4
 	move_to_delay = 5
-	attacktext = "destablizes"
+	attacktext = "destablized"
 
 	drop_items = list()
 
@@ -347,7 +347,7 @@
 	emote_see = list("looks left then right", "breaths heavilly", "adjusts their armour")
 	turns_per_move = 4
 	move_to_delay = 5
-	attacktext = "hacks"
+	attacktext = "hacked"
 
 	drop_items = list()
 
@@ -366,7 +366,7 @@
 	emote_see = list("looks left then right.", "breathes softly.", "adjusts their robes.")
 	turns_per_move = 1
 	move_to_delay = 2
-	attacktext = "punches"
+	attacktext = "punched"
 
 	drop_items = list()
 
@@ -385,7 +385,7 @@
 	emote_see = list("looks left then right.", "breathes softly.", "adjusts their robes.")
 	turns_per_move = 1
 	move_to_delay = 2
-	attacktext = "punches"
+	attacktext = "punched"
 
 	drop_items = list()
 
@@ -425,7 +425,7 @@
 	emote_see = list("looks left then right.", "breathes softly.", "adjusts their robes.")
 	turns_per_move = 1
 	move_to_delay = 2
-	attacktext = "punches"
+	attacktext = "punched"
 
 	drop_items = list()
 

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/bishop.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/bishop.dm
@@ -6,7 +6,7 @@
 	fleshcolor = "#964B00"
 	bloodcolor = "#964B00"
 	icon_state = "bishop_golem"
-	attacktext = "glares"
+	attacktext = "glared at"
 	fire_verb = "casts a flarming ball of plasma"
 	ranged = TRUE
 	move_to_delay = 4

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/knight.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/knight.dm
@@ -4,7 +4,7 @@
 	desc = "The Vassal, an Automaton made by the Custodians and fashioned after a solemn warrior. Reliable, strong, and quite sturdy."
 	faction = "neutral"
 	icon_state = "vassal_automaton"
-	attacktext = "strikes"
+	attacktext = "striken"
 	fleshcolor = "#964B00"
 	bloodcolor = "#964B00"
 	move_to_delay = 3

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/pawn.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/pawn.dm
@@ -4,7 +4,7 @@
 	their twin blades and light armor make them an extremely fast and heavy striker."
 	faction = "neutral"
 	icon_state = "pawn_golem"
-	attacktext = "duel strikes"
+	attacktext = "dual striken"
 	fleshcolor = "#964B00"
 	bloodcolor = "#964B00"
 	move_to_delay = 2

--- a/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/rook.dm
+++ b/code/modules/mob/living/carbon/superior_animal/robots/subtype/church/types/rook.dm
@@ -6,7 +6,7 @@
 	icon_state = "suzerain_automaton"
 	fleshcolor = "#964B00"
 	bloodcolor = "#964B00"
-	attacktext = "pumbles"
+	attacktext = "pumbled"
 	move_to_delay = 5 //Slowdown!
 	turns_per_move = 5
 	meat_amount = 3 // Chunky boi

--- a/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_defines.dm
@@ -168,7 +168,7 @@
 	*/
 
 	var/deathmessage = "dies."
-	var/attacktext = "bitten"
+	var/attacktext = "bitten" // For reference, these verbs should be worded in plusquamperfect as they will always be preceded by "has". E.g: "[attacker] has [attacktext] [target]" or "has blocked being [attack_verb] by [attacker]"
 	var/list/attack_sound = 'sound/weapons/spiderlunge.ogg'
 	var/attack_sound_chance = 100
 	var/attack_sound_volume = 90

--- a/code/modules/mob/living/carbon/superior_animal/vox/types/vox_types.dm
+++ b/code/modules/mob/living/carbon/superior_animal/vox/types/vox_types.dm
@@ -129,7 +129,7 @@
 	melee_damage_lower = 23
 	melee_damage_upper = 20
 
-	attacktext = "slashes"
+	attacktext = "slashed"
 
 	knock_over_odds = 30
 

--- a/code/modules/mob/living/carbon/superior_animal/vox/types/wasp.dm
+++ b/code/modules/mob/living/carbon/superior_animal/vox/types/wasp.dm
@@ -13,7 +13,7 @@
 	see_in_dark = 10
 	speak_emote = list("buzzes loudly.")
 	emote_see = list("looks around for a target.")
-	attacktext = "stings"
+	attacktext = "stung"
 	meat_amount = 4
 	meat_type = /obj/item/reagent_containers/food/snacks/meat
 	mob_size = MOB_MEDIUM

--- a/code/modules/mob/living/carbon/superior_animal/vox/vox.dm
+++ b/code/modules/mob/living/carbon/superior_animal/vox/vox.dm
@@ -12,7 +12,7 @@
 	see_in_dark = 10
 	speak_emote = list("grumbles")
 	emote_see = list("looks around for a target.")
-	attacktext = "claws"
+	attacktext = "clawed"
 	meat_amount = 4
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/chicken/vox
 	mob_size = MOB_MEDIUM

--- a/code/modules/mob/living/simple_animal/hostile/bat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bat.dm
@@ -17,7 +17,7 @@
 	harm_intent_damage = 8
 	melee_damage_lower = 10
 	melee_damage_upper = 10
-	attacktext = "bites"
+	attacktext = "bitten"
 	attack_sound = 'sound/weapons/bite.ogg'
 	inherent_mutations = list(MUTATION_BLINDNESS, MUTATION_ECHOLOCATION, MUTATION_TOXIN_RESISTANCE, MUTATION_BLOOD_BANK)
 

--- a/code/modules/mob/living/simple_animal/hostile/creature.dm
+++ b/code/modules/mob/living/simple_animal/hostile/creature.dm
@@ -43,7 +43,7 @@
 	maxHealth = 100
 	melee_damage_lower = 5
 	melee_damage_upper = 10
-	attacktext = "hits"
+	attacktext = "hit"
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/human
 
 /mob/living/simple_animal/hostile/retaliate/spaceman/leader
@@ -58,7 +58,7 @@
 	maxHealth = 200
 	melee_damage_lower = 20
 	melee_damage_upper = 40
-	attacktext = "hits"
+	attacktext = "hit"
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/human
 
 /mob/living/simple_animal/hostile/madminer
@@ -73,7 +73,7 @@
 	maxHealth = 100
 	melee_damage_lower = 10
 	melee_damage_upper = 15
-	attacktext = "hits"
+	attacktext = "hit"
 	sanity_damage = 1
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/human
 	attack_sound = 'sound/weapons/rapierhit.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/clown.dm
@@ -129,7 +129,7 @@
 	harm_intent_damage = 1
 	melee_damage_lower = 1
 	melee_damage_upper = 1
-	attacktext = "cheers up"
+	attacktext = "cheered up"
 
 /mob/living/simple_animal/hostile/retaliate/clown/stacked
 	name = "Clowns"
@@ -143,7 +143,7 @@
 	harm_intent_damage = 10
 	melee_damage_lower = 10
 	melee_damage_upper = 10
-	attacktext = "punches in unison"
+	attacktext = "punched in unison"
 	pixel_x = -20
 
 /mob/living/simple_animal/hostile/retaliate/clown/fleshclown
@@ -161,7 +161,7 @@
 	health = 300
 	speed = -5
 	melee_damage_upper = 15
-	attacktext = "limply slaps"
+	attacktext = "limply slapped"
 
 /mob/living/simple_animal/hostile/retaliate/clown/longface
 	name = "Longface"
@@ -181,7 +181,7 @@
 	speed = 10
 	harm_intent_damage = 5
 	melee_damage_lower = 5
-	attacktext = "YA-HONKs"
+	attacktext = "YA-HONKed"
 
 /mob/living/simple_animal/hostile/retaliate/clown/scary
 	name = "Copyright Infringement"
@@ -200,7 +200,7 @@
 	speed = 10
 	harm_intent_damage = 30
 	melee_damage_lower = 40
-	attacktext = "copyright claims"
+	attacktext = "copyright claimed"
 
 /mob/living/simple_animal/hostile/retaliate/clown/clownhulk
 	name = "Honk Hulk"
@@ -219,7 +219,7 @@
 	speed = 2
 	melee_damage_lower = 40
 	melee_damage_upper = 50
-	attacktext = "pummels"
+	attacktext = "pummeled"
 
 /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown
 	name = "Chlown"
@@ -236,7 +236,7 @@
 	speed = -2
 	melee_damage_lower = 20
 	melee_damage_upper = 25
-	attacktext = "steals the girlfriend of"
+	attacktext = "stolen the girlfriend out of"
 	attack_sound = 'sound/items/Airhorn.ogg'
 
 /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus
@@ -254,7 +254,7 @@
 	speed = -5
 	melee_damage_lower = 15
 	melee_damage_upper = 20
-	attacktext = "ferociously mauls"
+	attacktext = "ferociously mauled"
 	attack_reagent = "mindbreaker"
 
 /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/destroyer
@@ -270,7 +270,7 @@
 	speed = 5
 	melee_damage_lower = 20
 	melee_damage_upper = 40
-	attacktext = "acts out divine vengeance on"
+	attacktext = "acted out divine vengeance upon"
 
 /mob/living/simple_animal/hostile/retaliate/clown/mutant
 	name = "Unknown"
@@ -290,7 +290,7 @@
 	speed = -5
 	melee_damage_lower = 10
 	melee_damage_upper = 20
-	attacktext = "awkwardly flails at"
+	attacktext = "awkwardly flailed at"
 
 /mob/living/simple_animal/hostile/retaliate/clown/mutant/blob
 	name = "Something that was once a clown"
@@ -303,6 +303,6 @@
 	health = 400
 	mob_size = MOB_LARGE
 	speed = 20
-	attacktext = "bounces off of"
+	attacktext = "bounced out of"
 	attack_reagent = "mindbreaker"
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -73,9 +73,9 @@
 	var/min_n2 = 0
 	var/max_n2 = 0
 	var/unsuitable_atoms_damage = 2	//This damage is taken when atmos doesn't fit all the requirements above
-	var/speed = 2 //LETS SEE IF I CAN SET SPEEDS FOR SIMPLE MOBS WITHOUT DESTROYING EVERYTHING. Higher speed is slower, negative speed is faster
+	var/speed = 2 // Higher numbers are slower, negative numbers are faster
 
-	var/attacktext = "attacked"
+	var/attacktext = "attacked" // For reference, these verbs should be mostly worded in plusquamperfect as they will always be preceded by "has". E.g: "[attacker] has [attacktext] [target]" or "has blocked being [attack_verb] by [attacker]"
 	var/attack_sound = null
 	var/friendly = "nuzzles"
 	var/environment_smash = 0

--- a/code/modules/mob/living/simple_animal/spider_core.dm
+++ b/code/modules/mob/living/simple_animal/spider_core.dm
@@ -18,7 +18,7 @@
 	a_intent = I_HURT
 	stop_automated_movement = 1
 	status_flags = CANPUSH
-	attacktext = "stabed"
+	attacktext = "stabbed"
 	friendly = "punched"
 	harm_intent_damage = 1
 	wander = 0

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -30,7 +30,7 @@ In pvp they also have more lasting damages, such as infections, pain form burns,
 		var/obj/item/shield/S = A
 		var/loss = round(S.durability / armor_penetration / 8)
 		block_damage(loss, A)
-		A.visible_message(SPAN_WARNING("\The [src] is weakened by the \the [A]!"))
+		A.visible_message(SPAN_WARNING("\The [src] is weakened by \the [A]!"))
 		playsound(A.loc, 'sound/weapons/shield/shielddissipate.ogg', 50, 1)
 		return 1
 	return 0

--- a/code/modules/projectiles/projectile/plasma.dm
+++ b/code/modules/projectiles/projectile/plasma.dm
@@ -199,7 +199,7 @@
 		var/obj/item/shield/S = A
 		var/loss = round(S.durability / armor_penetration / 8)
 		block_damage(loss, A)
-		A.visible_message(SPAN_WARNING("\The [src] is weakened by the \the [A]!"))
+		A.visible_message(SPAN_WARNING("\The [src] is weakened by \the [A]!"))
 		playsound(A.loc, 'sound/weapons/shield/shielddissipate.ogg', 50, 1)
 		return TRUE
 	else if(istype(A, /obj/structure/barricade) || istype(A, /obj/structure/table) || istype(A, /obj/structure/low_wall))

--- a/code/modules/reagents/reagent_containers/food/snacks/advanced_food.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/advanced_food.dm
@@ -148,8 +148,8 @@
 
 /obj/item/reagent_containers/food/snacks/openable/can
 	name = "ration can"
-	desc = "Can of stew meat, tab right on top for easy opening."
-	alt_desc = "An opened can of stewed meat, ready for consumption."
+	desc = "Can of stew meat, tab right on top for easy opening. Twist the bottom to start the self-heating process, becoming a better meal."
+	alt_desc = "An opened can of hot, stewed meat ready for consumption."
 	icon_state = "ration_can"
 	trash = /obj/item/trash/mre_can
 	filling_color = "#948051"
@@ -208,7 +208,7 @@
 
 /obj/item/reagent_containers/food/snacks/openable/selfheat_coffee
 	name = "Self-Heating Coffee Thermos Can"
-	desc = "A can-shaped thermos of pure black coffee with a self-heating mechanism. A survivalist's best friend, it requires no fire - just open up, shake and wait before drinking!"
+	desc = "A can-shaped disposable thermos of pure black coffee with a self-heating mechanism. A survivalist's best friend, it requires no fire - just open up, twist the bottom and wait before drinking!"
 	alt_desc = "A can-shaped thermos of pure black coffee, piping hot and ready to warm you up."
 	icon_state = "selfheat_coffee"
 	trash = /obj/item/trash/selfheat_coffee
@@ -223,6 +223,39 @@
 	matter = list(MATERIAL_BIOMATTER = 6)
 	can_warm = TRUE
 	volume = 50 //Little extra space for the nutriments
+
+/obj/item/reagent_containers/food/snacks/openable/selfheat_coffee/examine(mob/user)
+	if(!..(user, get_dist(user, src)))
+		return
+	if (bitecount==0)
+		return
+	else if (bitecount==1)
+		to_chat(user, SPAN_NOTICE("Someone has drank a bit of \the [src]!"))
+	else if (bitecount<=3)
+		to_chat(user, SPAN_NOTICE("Someone has drank from \the [src] approximately [bitecount] time\s!"))
+	else
+		to_chat(user, SPAN_NOTICE("Looks like there's not much coffee left inside \the [src]!"))
+
+/obj/item/reagent_containers/food/snacks/openable/selfheat_coffee/attack_self(mob/user)
+	if(!open)
+		open()
+		to_chat(user, SPAN_NOTICE("You open the tab on \the [src]."))
+		playsound(src, 'sound/effects/canopen.ogg', 50, 1, 1)
+		return
+	if(warm)
+		to_chat(user, SPAN_NOTICE("You already started the heat up process of \the [src], be patient until it's warm."))
+		return
+	if(can_warm)
+		user.visible_message(
+			SPAN_NOTICE("[user] gently twists \the [src]."),
+			"You gently twist the bottom of \the [src] and feel a comfortable heat build up.",
+			playsound(src, 'sound/effects/insert.ogg', 50, 1, 1)
+		)
+		warm = TRUE
+		spawn(300)
+			to_chat(user, "You think \the [src] is hot enough to drink about now.")
+			playsound(src, 'sound/items/smoking.ogg', 50, 1, 1)
+			heat()
 
 // Despite its code path, it's a drink, not a snacc!
 // Until food feeding is replaced with a generalized standard_mob_feed(), this needs to be here for the drink sound to play

--- a/code/modules/tables/sandbags.dm
+++ b/code/modules/tables/sandbags.dm
@@ -60,7 +60,7 @@
 	if(damage)//Occulus edit
 		damage(damage)//Occulus Edit
 		attack_animation(user)
-		visible_message(SPAN_DANGER("[user] [attack_message] the [src]!"))
+		visible_message(SPAN_DANGER("\The [user] has [attack_message] \the [src]!"))
 		return 1
 
 /obj/structure/sandbags/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)

--- a/code/modules/vehicles/vehicle.dm
+++ b/code/modules/vehicles/vehicle.dm
@@ -378,7 +378,7 @@
 /obj/vehicle/attack_generic(var/mob/user, var/damage, var/attack_message)
 	if(!damage)
 		return
-	visible_message(SPAN_DANGER("\The [user] [attack_message] the \the [src]!"))
+	visible_message(SPAN_DANGER("The [user] has [attack_message] [src]!"))
 	if(istype(user))
 		user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked \the [src.name]</font>")
 		user.do_attack_animation(src)

--- a/modular_liberty/shields.dm
+++ b/modular_liberty/shields.dm
@@ -120,7 +120,7 @@
 	if(damage)//Occulus edit
 		damage(damage)//Occulus Edit
 		attack_animation(user)
-		visible_message(SPAN_DANGER("[user] [attack_message] the [src]!"))
+		visible_message(SPAN_DANGER("\The [user] has [attack_message] \the [src]!"))
 		return 1
 
 /obj/structure/shield_deployed/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)


### PR DESCRIPTION
## About The Pull Request

- Makes self heating coffee cans less food and more can (fixes sounds and examine descriptions)
- Fixes floodlights turning into gate floodlights when turned on
- Many additional "the" 's deleted
- Admin logs for whenever someone picks a marking so we can oust the sparkledogs and pinpoint causes of lag (until we get better mannequin code...)
- Fixes many attack verbs, and enhances grammatical consistency on printed texts for generic attacks (and blocks), leaving a code comment for documentation
- Chameleon accesories now working again as intended
- Fixes tripping on underplating not displaying a proper message as intended, readds sounds so that people are more keenly aware they just tripped

<hr>


## Changelog
:cl:
fix: Fixes floodlights turning into gate floodlights when turned on
fix: Makes coffee cans less MRE children and more "drink" (examine text descriptions, sounds for opening, preparing and heating)
fix: Chameleon accesories now working again as intended
fix: Message for tripping on underplating now shown, sounds added back so that people are more aware they just tripped
spellcheck:  Fixes many mob attack verbs, and enhances grammatical consistency on printed texts for generic attacks (and blocks), leaving a code comment for documentation
admin: Admin logs for whenever someone picks a marking so we can oust the sparkledogs and pinpoint causes of lag (until we get better mannequin code...)
/:cl: