### PR TITLE
Club Manager Alt Titles & Cloak Tweaks

### DIFF
--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -7,8 +7,9 @@
 	faction = MAP_FACTION
 	total_positions = 1
 	spawn_positions = 1
-	supervisors = "You"
+	supervisors = "Money."
 	difficulty = "Medium."
+	alt_titles = list("Chief Sales Officer", "Tradesman", "Sales Manager")
 	selection_color = "#dddddd"
 	access = list(access_merchant, access_janitor, access_hydroponics, access_bar, access_kitchen, access_heads, access_cargo, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
 

--- a/code/game/jobs/job/service.dm
+++ b/code/game/jobs/job/service.dm
@@ -9,7 +9,7 @@
 	spawn_positions = 1
 	supervisors = "Money."
 	difficulty = "Medium."
-	alt_titles = list("Chief Sales Officer", "Tradesman", "Sales Manager")
+	alt_titles = list("Chief Sales Officer", "Pusher", "Sales Manager")
 	selection_color = "#dddddd"
 	access = list(access_merchant, access_janitor, access_hydroponics, access_bar, access_kitchen, access_heads, access_cargo, access_RC_announce, access_keycard_auth, access_tcomsat, access_ai_upload)
 

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -373,7 +373,7 @@
 
 /obj/item/clothing/accessory/halfcape/ceo
 	name = "affluent skylight holo-mantle"
-	desc = "A fancy holo-mantle made from light-toned silk and bearing the rank markings of a high ranking skylight representative. Fine alabaster silks and gold trim, despite its seemingly similar \
+	desc = "A fancy holo-mantle made from light-toned silk and bearing the markings of a high ranking skylight representative. Made of fine alabaster silks and trimmed in gold , despite its design being so closely \
 	make to similar cloaks, its quality cannot be contested."
 	icon_state = "half_ceo"
 

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -323,7 +323,7 @@
 	desc = "A black cloak with dark-blue lining."
 
 /obj/item/clothing/accessory/job/cape/gm
-	name = "club manager's cloak"
+	name = "skylight cloak"
 	icon_state = "gmcloak"
 	desc = "A brown cloak with yellow lining."
 
@@ -372,8 +372,8 @@
 	icon_state = "half_nt"
 
 /obj/item/clothing/accessory/halfcape/ceo
-	name = "club manager's holo-mantle"
-	desc = "A fancy holo-mantle made from light-toned silk and bearing the rank markings of the Club Manager. Fine alabaster silks and gold trim, despite its seemingly similar \
+	name = "affluent skylight holo-mantle"
+	desc = "A fancy holo-mantle made from light-toned silk and bearing the rank markings of a high ranking skylight representative. Fine alabaster silks and gold trim, despite its seemingly similar \
 	make to similar cloaks, its quality cannot be contested."
 	icon_state = "half_ceo"
 

--- a/code/modules/clothing/accessories/accessory.dm
+++ b/code/modules/clothing/accessories/accessory.dm
@@ -374,7 +374,7 @@
 /obj/item/clothing/accessory/halfcape/ceo
 	name = "affluent skylight holo-mantle"
 	desc = "A fancy holo-mantle made from light-toned silk and bearing the markings of a high ranking skylight representative. Made of fine alabaster silks and trimmed in gold , despite its design being so closely \
-	make to similar cloaks, its quality cannot be contested."
+	similar to low council cloaks, its quality cannot be contested."
 	icon_state = "half_ceo"
 
 /obj/item/clothing/accessory/halfcape/premier


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	This PR was made to give diversity to the Club Manager role by giving them alternate title names. Club Manager was a bit deterministic so this gives people mobility to do stuff.
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:
adds: job manager alt names.
tweak: renames the cloak names to be job title neutral.
/:cl: