### PR TITLE
Oathpledge locker quickfix

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -157,7 +157,7 @@
 	req_access = list(access_oathpledge)
 	icon_state = "oathpledge"
 
-/obj/structure/closet/oathpledge/populate_contents()
+/obj/structure/closet/secure_closet/reinforced/oathpledge/populate_contents()
 	if(prob(25))
 		new /obj/item/storage/backpack/custodian(src)
 	else if(prob(25))


### PR DESCRIPTION
## About The Pull Request

Bad pathing on populate_contents proc made it empty on initialization, this should fix the proc by using proper pathing

## Changelog
:cl:
fix: Oathpledge locker now properly has its intended contents instead of being empty
/:cl: