### PR TITLE
custodian tweaks again

### DIFF
--- a/code/datums/autolathe/biomatter.dm
+++ b/code/datums/autolathe/biomatter.dm
@@ -61,15 +61,15 @@
 	build_path = /obj/item/storage/backpack/satchel
 
 /datum/design/bioprinter/leather/storage/backpack/satchel/custodian
-	name = "Cruciform  Satchel"
+	name = "Custodian Satchel"
 	build_path = /obj/item/storage/backpack/satchel/custodian
 
 /datum/design/bioprinter/leather/storage/backpack/custodian
-	name = "Cruciform Backpack"
+	name = "Custodian Backpack"
 	build_path = /obj/item/storage/backpack/custodian
 
 /datum/design/bioprinter/leather/storage/backpack/sport/custodian
-	name = "Cruciform Sport Backpack"
+	name = "Custodian Sport Backpack"
 	build_path = /obj/item/storage/backpack/sport/custodian
 
 /datum/design/bioprinter/leather/holster

--- a/code/game/objects/items/weapons/nt_melee.dm
+++ b/code/game/objects/items/weapons/nt_melee.dm
@@ -28,8 +28,9 @@
 	force = WEAPON_FORCE_DANGEROUS
 	throwforce = WEAPON_FORCE_WEAK
 	armor_penetration = ARMOR_PEN_DEEP
-	price_tag = 300
+	price_tag = 650
 	matter = list(MATERIAL_BIO_SILK = 15, MATERIAL_PLASTIC = 10, MATERIAL_STEEL = 10)
+	alt_mode_lossrate = 0.7
 
 /obj/item/tool/sword/custodian/horseaxe
 	name = "horseman axe"
@@ -42,7 +43,8 @@
 	armor_penetration = ARMOR_PEN_EXTREME
 	w_class = ITEM_SIZE_BULKY
 	slot_flags = SLOT_BACK | SLOT_BELT
-	price_tag = 500
+	price_tag = 850
+	alt_mode_lossrate = 0.7
 	matter = list(MATERIAL_BIO_SILK = 15, MATERIAL_PLASTIC = 10, MATERIAL_PLASTEEL = 16, MATERIAL_STEEL = 30, MATERIAL_CARBON_FIBER = 8)
 	item_icons = list(
 		slot_back_str = 'icons/inventory/back/mob.dmi')
@@ -58,7 +60,7 @@
 	item_state = "custodian_seax"
 	force = WEAPON_FORCE_PAINFUL
 	armor_penetration = ARMOR_PEN_MASSIVE
-	price_tag = 120
+	price_tag = 300
 	matter = list(MATERIAL_BIO_SILK = 10, MATERIAL_STEEL = 10)
 
 /obj/item/tool/knife/dagger/custodian/equipped(mob/living/M)
@@ -79,7 +81,7 @@
 	force = WEAPON_FORCE_BRUTAL
 	armor_penetration = ARMOR_PEN_MASSIVE
 	slot_flags = SLOT_BACK | SLOT_BELT
-	price_tag = 600
+	price_tag = 850
 	matter = list(MATERIAL_STEEL = 15, MATERIAL_PLASTEEL = 8, MATERIAL_BIO_SILK = 15, MATERIAL_PLASTIC = 10, MATERIAL_WOOD = 10, MATERIAL_CARBON_FIBER = 15)
 	item_icons = list(
 		slot_back_str = 'icons/inventory/back/mob.dmi')
@@ -124,7 +126,8 @@
 	throwforce = WEAPON_FORCE_LETHAL * 1.5
 	armor_penetration = ARMOR_PEN_MODERATE
 	throw_speed = 4
-	price_tag = 150
+	price_tag = 400
+	alt_mode_lossrate = 0.7
 	matter = list(MATERIAL_BIO_SILK = 15, MATERIAL_PLASTEEL = 2, MATERIAL_STEEL = 5)
 
 /obj/item/tool/sword/custodian/throwaxe/equipped(mob/living/W)
@@ -156,7 +159,8 @@
 	sharp = FALSE
 	embed_mult = 0
 	has_alt_mode = FALSE
-	var/effect_time = 5 MINUTES
+	var/effect_time = 3 MINUTES
+	var/power_cost = 20
 	hitsound = 'sound/weapons/blunthit.ogg'
 
 /obj/item/tool/sword/custodian/warhammer/attack_self(mob/user)
@@ -165,18 +169,19 @@
 	if(!CI || !CI.active || !CI.wearer || !istype(CI,/obj/item/implant/core_implant/cruciform))
 		to_chat(user, SPAN_WARNING("You do not have an active Hearthcore with which to power this!"))
 		return
-	if(CI.power < 20)
+	if(CI.power < power_cost)
 		to_chat(user, SPAN_WARNING("You do not have enough power!"))
 		return
 	if(glowing)
 		to_chat(user, SPAN_WARNING("The warhammer is still lit up."))
 		return
 	else
+		CI.use_power(power_cost)
 		heat_hammer()
 
 /obj/item/tool/sword/custodian/warhammer/proc/heat_hammer()
 	set_light(l_range = 4, l_power = 2, l_color = COLOR_YELLOW)
-	visible_message("[src] radiates a searing heat!")
+	visible_message(SPAN_NOTICE("[src] radiates a searing heat!"))
 	glowing = TRUE
 	heat = 1873
 	update_icon()
@@ -190,7 +195,7 @@
 	damtype = initial(damtype)
 	heat = initial(heat)
 	update_icon()
-	visible_message("[src]'s heat dies down.")
+	visible_message(SPAN_NOTICE("[src]'s heat dies down."))
 
 /obj/item/tool/sword/custodian/warhammer/update_icon()
 	if(glowing)
@@ -207,13 +212,15 @@
 	force = WEAPON_FORCE_BRUTAL
 	armor_penetration = ARMOR_PEN_DEEP
 	w_class = ITEM_SIZE_BULKY
-	price_tag = 800
+	price_tag = 1200
+	alt_mode_lossrate = 0.7
 	matter = list(MATERIAL_BIO_SILK = 40, MATERIAL_STEEL = 15, MATERIAL_CARBON_FIBER = 15, MATERIAL_SILVER = 6, MATERIAL_PLASTEEL = 8, MATERIAL_PLASTIC = 20, MATERIAL_WOOD = 10)
 	tool_qualities = list(QUALITY_CUTTING = 10)
 	var/glowing = FALSE
 	slot_flags = SLOT_BACK | SLOT_BELT
 	has_alt_mode = FALSE
-	var/effect_time = 5 MINUTES //used for the addtimer() proc
+	var/effect_time = 1 MINUTES //used for the addtimer() proc
+	var/power_cost = 45
 	item_icons = list(
 		slot_back_str = 'icons/inventory/back/mob.dmi') //this is how to set the back sprite
 	item_state_slots = list(
@@ -226,24 +233,25 @@
 	if(!CI || !CI.active || !CI.wearer || !istype(CI,/obj/item/implant/core_implant/cruciform)) //Active hearthcore check
 		to_chat(user, SPAN_WARNING("You do not have an active Hearthcore with which to power this!"))
 		return
-	if(CI.power < 20)
+	if(CI.power < power_cost)
 		to_chat(user, SPAN_WARNING("You do not have enough power!"))
 		return
 	if(glowing)
 		to_chat(user, SPAN_WARNING("The sword is still lit up."))
 		return
 	else
+		CI.use_power(power_cost)
 		ignite_sword(user)
 
 /obj/item/tool/sword/custodian/conflagration/apply_hit_effect(mob/living/target, mob/living/user, hit_zone)
 	..() //We first let the base apply_hit_effect() proc do its thing, attacking with the sword
 	if (glowing) //then we check if we burn the target
 		if (iscarbon(target))
-			scorch_attack(target, 10)
+			scorch_attack(target, 20)
 
 /obj/item/tool/sword/custodian/conflagration/proc/ignite_sword(mob/user)
 	set_light(l_range = 4, l_power = 2, l_color = COLOR_BLUE)
-	to_chat(user, SPAN_WARNING("The sword has been lit!"))
+	visible_message(SPAN_NOTICE("[user] infuses Radiance into [src]"))
 	glowing = TRUE
 	heat = 1873
 	update_icon()
@@ -260,7 +268,7 @@
 	update_icon()
 	user.update_inv_r_hand() //Get rid of the radiant sprites
 	user.update_inv_l_hand()
-	visible_message(SPAN_NOTICE("The sword's flames subside."))
+	visible_message(SPAN_NOTICE("[src]'s flames subside."))
 
 /obj/item/tool/sword/custodian/conflagration/update_icon() //Toggles the "turned on" icon and on-mob sprites based on the "glowing" var
 	if(glowing)
@@ -351,11 +359,11 @@
 	icon_state = "custodian_heater"
 	item_state = "custodian_heater"
 	matter = list(MATERIAL_STEEL = 20, MATERIAL_PLASTEEL = 8, MATERIAL_BIO_SILK = 15, MATERIAL_PLASTIC = 10, MATERIAL_WOOD = 10, MATERIAL_CARBON_FIBER = 15, MATERIAL_SILVER = 2)
-	price_tag = 300
+	price_tag = 500
 	base_block_chance = 45
 	item_flags = DRAG_AND_DROP_UNEQUIP
-	max_durability = 100 //So we can brake and need healing time to time
-	durability = 100
+	max_durability = 150 //So we can brake and need healing time to time
+	durability = 150
 	var/obj/item/storage/internal/container
 	var/storage_slots = 1
 	var/max_w_class = ITEM_SIZE_HUGE

--- a/code/modules/biomatter_manipulation/bioreactor/bioreactor.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/bioreactor.dm
@@ -123,7 +123,7 @@
 
 
 /obj/machinery/multistructure/bioreactor_part
-	name = "bioreactor part"
+	name = "bonfire part"
 	icon = 'icons/obj/machines/bonfire.dmi'
 	icon_state = "biomassconsole1"
 	anchored = TRUE

--- a/code/modules/biomatter_manipulation/bioreactor/biotank.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/biotank.dm
@@ -81,7 +81,7 @@
 				spill_biomass(get_turf(user), cardinal)
 			else if(dirtiness_lvl >= DIRT_LVL_HIGH)
 				spill_biomass(get_turf(user), alldirs)
-			scorch_attack(user, rand(5, 5*dirtiness_lvl))
+			scorch_attack(user)
 		else
 			to_chat(user, SPAN_WARNING("You need to stand still to clean it properly."))
 		update_icon()
@@ -189,12 +189,12 @@
 				else
 					set_canister(possible_canister)
 				to_chat(user, SPAN_NOTICE("You [canister ? "connect [canister] to" : "disconnect [canister] from"] [src]."))
-				scorch_attack(user, rand(5, 15))
+				scorch_attack(user)
 			else
 				to_chat(user, SPAN_WARNING("Ugh. You done something wrong!"))
 				shake_animation()
 				if(reagents.total_volume)
-					scorch_attack(user, rand(15, 25))
+					scorch_attack(user)
 					spill_biomass(user_interaction_loc)
 			update_icon()
 

--- a/code/modules/biomatter_manipulation/bioreactor/console.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/console.dm
@@ -3,7 +3,7 @@
 
 
 /obj/machinery/multistructure/bioreactor_part/console
-	name = "bioreactor metrics"
+	name = "bonfire metrics"
 	icon_state = "screen"
 	layer = ABOVE_MOB_LAYER + 0.1
 	idle_power_usage = 350

--- a/code/modules/biomatter_manipulation/bioreactor/loader.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/loader.dm
@@ -4,7 +4,7 @@
 
 
 /obj/machinery/multistructure/bioreactor_part/loader
-	name = "bioreactor input"
+	name = "bonfire input"
 	icon_state = "loader"
 	idle_power_usage = 120
 	active_power_usage = 300

--- a/code/modules/biomatter_manipulation/bioreactor/platform.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/platform.dm
@@ -5,7 +5,7 @@
 
 
 /obj/machinery/multistructure/bioreactor_part/platform
-	name = "bioreactor platform"
+	name = "bonfire platform"
 	icon_state = "platform_5"
 	density = FALSE
 	layer = LOW_OBJ_LAYER

--- a/code/modules/biomatter_manipulation/bioreactor/port.dm
+++ b/code/modules/biomatter_manipulation/bioreactor/port.dm
@@ -4,7 +4,7 @@
 
 
 /obj/machinery/multistructure/bioreactor_part/bioport
-	name = "biomatter port"
+	name = "scorchslag port"
 	icon_state = "port"
 	layer = LOW_OBJ_LAYER
 	density = FALSE

--- a/code/modules/biomatter_manipulation/toxic_biomass.dm
+++ b/code/modules/biomatter_manipulation/toxic_biomass.dm
@@ -1,16 +1,14 @@
 //burning biomass and a few procs used by biomatter manipulation machines
 
 
-//biomatter attack proc, it's used for attacking people with checking their armor
-/proc/scorch_attack(mob/living/victim, var/damage = rand(2, 4))
+//scorch attack proc, used to deal burn damage and firestacks through armor only checking for heat protection
+/proc/scorch_attack(mob/living/victim, var/damage = rand(20, 25))
 	if(istype(victim))
 		var/T = get_turf(victim)
-		var/hazard_damage = -100 + (victim.get_heat_protection() * 100)
+		var/hazard_damage = -100 + (victim.get_heat_protection() * 100) //get heat protection flags, if fully protected, don't trigger an attack
 		if(hazard_damage >= 0)
 			return
-		hazard_damage *= -1
-		hazard_damage *= 0.003 //Are armor still does SMOTHING
-		heatwave(T, 0, 0, 80 * hazard_damage, 3, 0)
+		heatwave(T, 0, 0, damage, 3, 0) //heatwave() already handles damage reduction based on heat protection flags
 
 //this proc spill some biomass on the floor
 //dirs_to_spread - list with dirs where biomass should expand after creation

--- a/code/modules/core_implant/cruciform/cruciform.dm
+++ b/code/modules/core_implant/cruciform/cruciform.dm
@@ -38,7 +38,7 @@ var/list/disciples = list()
 	if(!ishuman(wearer))
 		return
 	var/mob/living/carbon/human/H = wearer
-	name = "[H]'s Cruciform" //This is included here to make it obvious who a cruciform belonged to if it was surgically removed
+	name = "[H]'s Hearthcore" //This is included here to make it obvious who a Hearthcore belonged to if it was surgically removed
 	if(H.stat == DEAD)
 		return
 	if(!active)

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -95,7 +95,7 @@ datum/ritual/cruciform/base/thumbspire
 	name = "Pyrelight"
 	phrase = "Oxidate Lecture: Pyrelight."
 	desc = "Lecture of wandering Custodians that creates a small immobile light for twenty minutes."
-	power = 20
+	power = 10
 
 /datum/ritual/cruciform/base/pyrelight/perform(mob/living/carbon/human/H, obj/item/implant/core_implant/C)
 	playsound(H.loc, 'sound/effects/snap.ogg', 50, 1)
@@ -126,7 +126,10 @@ datum/ritual/cruciform/base/thumbspire
 	var/text = input(user, "What message will you send to the target? Only they will be able to hear it.", "Sending a message") as text|null
 	if (!text)
 		return FALSE
+	user.visible_message("[user] forms a small pigeon of light and releases it, the bird flying off at incredible speeds.")
+	to_chat(user, SPAN_NOTICE("You send a message to [target]: \"text\""))
 	to_chat(target, "<span class='notice'><b><font color='#ffaa00'>A nearly imperceptible pigeon of light hovers near your ears and resonates with [user.real_name]'s voice: \"[text]\"</font><b></span>")
+	target.visible_message("A tiny pigeon of light flies in and floats near [target]'s head, vibrates, and fades into nothingness.")
 	log_and_message_admins("[user.real_name] sent a message to [target] with text \"[text]\"")
 	playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
 	playsound(target, 'sound/machines/signal.ogg', 50, 1)

--- a/code/modules/core_implant/cruciform/rituals/group.dm
+++ b/code/modules/core_implant/cruciform/rituals/group.dm
@@ -2,7 +2,7 @@
 /datum/ritual/group/cruciform
 	implant_type = /obj/item/implant/core_implant/cruciform
 	success_message = "On the verge of audibility you hear pleasant music, your mind clears up and the spirit grows stronger. Your prayer was heard."
-	fail_message = "The Cruciform feels cold against your chest."
+	fail_message = "The Hearthcore feels cold against your chest."
 	var/high_ritual = TRUE
 
 /datum/ritual/group/cruciform/pre_check(mob/living/carbon/human/user, obj/item/implant/core_implant/C, targets)

--- a/code/modules/core_implant/cruciform/rituals/machinery.dm
+++ b/code/modules/core_implant/cruciform/rituals/machinery.dm
@@ -4,7 +4,7 @@
 	name = "machines"
 	phrase = null
 	implant_type = /obj/item/implant/core_implant/cruciform
-	fail_message = "The Cruciform feels cold against your chest."
+	fail_message = "The Hearthcore feels cold against your chest."
 	category = "Machinery"
 	ignore_stuttering = TRUE
 

--- a/code/modules/core_implant/cruciform/rituals/path.dm
+++ b/code/modules/core_implant/cruciform/rituals/path.dm
@@ -79,7 +79,7 @@ datum/ritual/cruciform/oathbound/fireball
 	damage_types = list(BURN = WEAPON_FORCE_NORMAL) //deal 10 burn
 
 /obj/item/projectile/custodian_fireball/on_impact(atom/target)
-	scorch_attack(target, 20) //now that you've hit something, trigger a scorch attack of 20 damage
+	scorch_attack(target) //now that you've hit something, trigger a scorch attack of 20 damage
 	return TRUE
 
 /* might exist eventually, might not
@@ -260,7 +260,7 @@ datum/ritual/cruciform/oathbound/fireball_big
 /datum/ritual/cruciform/oathbound/ignite_flesh/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)
 	for(var/mob/living/M in view(2, user)) //get everything alive
 		if(!M.get_core_implant(/obj/item/implant/core_implant/cruciform)) //no hearthcore users
-			scorch_attack(M, 10) //trigger scorch attack
+			scorch_attack(M) //trigger scorch attack
 	user.visible_message(SPAN_DANGER("A wave of flame radiates out from [user]!"))
 	return TRUE
 
@@ -618,15 +618,11 @@ datum/ritual/cruciform/oathbound/fireball_big
 	phrase = "Oxidate Lecture: Tools of Bonfire."
 	desc = "Channels the power of your Hearthcore into an incorporeal omnitool."
 	power = 40
-	cooldown = TRUE
-	cooldown_time = 2 MINUTES
-	cooldown_category = "omnitool_lecture"
 	success_message = "Your hand glows with radiant light, and you feel more in tune with the machinery around you."
 
 /datum/ritual/cruciform/forgemaster/tools_of_bonfire/perform(mob/living/carbon/human/user, obj/item/implant/core_implant/C)
 	var/obj/item/tool/factorial_omni/tool = new /obj/item/tool/factorial_omni(src, user) //create the omni-tool
 	usr.put_in_hands(tool) //put it in the active hand
-	set_personal_cooldown(user)
 	return TRUE //refer to code\game\objects\items\weapons\tools\misc.dm for factorial_omni
 
 //datum/ritual/cruciform/forgemaster/flame_guidance - Refer to code\modules\core_implant\cruciform\rituals\construction.dm
@@ -968,7 +964,7 @@ datum/ritual/cruciform/oathbound/fireball_big
 		CI.uninstall()
 		return TRUE
 
-	else if(ismob(M) && is_dead(M)) //Cruciforms can't normally be placed on non-humans, but this is still here for sanity purposes.
+	else if(ismob(M) && is_dead(M)) //Hearthcores can't normally be placed on non-humans, but this is still here for sanity purposes.
 		CI.name = "[M]'s Hearthcore"
 		CI.uninstall()
 		return TRUE

--- a/code/modules/core_implant/cruciform/upgrades.dm
+++ b/code/modules/core_implant/cruciform/upgrades.dm
@@ -1,6 +1,6 @@
 /obj/item/cruciform_upgrade
-	name = "Base Cruciform Upgrade"
-	desc = "Cruciform upgrade, is now part of our reality."
+	name = "Base Hearthcore Upgrade"
+	desc = "Hearthcore upgrade, is now part of our reality."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "core_upgrade"
 	var/mob/living/carbon/human/wearer

--- a/code/modules/genetics/creatures/wasonce.dm
+++ b/code/modules/genetics/creatures/wasonce.dm
@@ -94,7 +94,7 @@ Has ability of every roach.
 			var/obj/item/implant/core_implant/cruciform/CI = h_victim.get_core_implant(/obj/item/implant/core_implant/cruciform, FALSE)
 			if (CI)
 				var/mob/N = CI.wearer
-				CI.name = "[N]'s Cruciform"
+				CI.name = "[N]'s Hearthcore"
 				CI.uninstall()
 
 		akira.loc = src

--- a/code/modules/mob/living/carbon/superior_animal/roach/life.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/life.dm
@@ -90,7 +90,7 @@
 									var/obj/item/implant/core_implant/cruciform/CI = H.get_core_implant(/obj/item/implant/core_implant/cruciform, FALSE)
 									if (CI)
 										var/mob/N = CI.wearer
-										CI.name = "[N]'s Cruciform"
+										CI.name = "[N]'s Hearthcore"
 										CI.uninstall()
 									// Gib victim but remove non synthetic organs
 									for(var/obj/item/W in H)

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -525,7 +525,7 @@
 	for(var/mob/living/creature in living_mobs_in_view(1, src))
 		if(creature.faction == "spiders")
 			continue
-		scorch_attack(creature, rand(1, 3))
+		scorch_attack(creature)
 
 /obj/effect/decal/cleanable/scorch_puddle/attackby(var/obj/item/I, var/mob/user)
 	if(istype(I, /obj/item/mop) || istype(I, /obj/item/soap))

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -781,7 +781,7 @@
 	..()
 
 /datum/reagent/toxin/liquid_scorch/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
-	scorch_attack(M, 20)
+	scorch_attack(M)
 	..()
 
 /datum/reagent/toxin/liquid_scorch/touch_turf(turf/T)


### PR DESCRIPTION
I had these sitting on my machine for a while, might as well push them.

Corrects "Cruciform" and "Bioreactor" names in a few places.

Changes scorch_attack() to not have hardcoded damage, now it can be changed when called

Adds visible messages and texts to Carrier Pigeon to not make it look like telepathy as much.

Makes power-using weapons actually consume power, buff durations and costs changed.

Makes custodian weapons more expensive and makes a few have less harsh alt_mode penalties.