### PR TITLE
Soil craft time reduction

### DIFF
--- a/code/datums/craft/recipes/furniture.dm
+++ b/code/datums/craft/recipes/furniture.dm
@@ -183,7 +183,7 @@
 /datum/craft_recipe/furniture/soilbed
 	name = "soil"
 	result = /obj/machinery/portable_atmospherics/hydroponics/soil
-	time = 90
+	time = 30
 	icon_state = "woodworking"
 	steps = list(
 		list(/obj/item/stack/ore, 5),


### PR DESCRIPTION
Reduces the crafting time of the Soil bed for crops by 30%

Huge timesink if you want to do it in mass, no tools being used that could speed up the process.

Heavily a personal tweak, for convenience.

It compiles, and there's nothing to really screenshot to show it working in action. so.

![image](https://github.com/Liberty-Landing/Liberty-Station-13/assets/47806118/2caf9f8e-a397-4606-bcb6-b3e6983889e5)
