### PR TITLE
Slight edit to AI_inactive stuff.

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
+++ b/code/modules/mob/living/carbon/superior_animal/superior_animal.dm
@@ -563,6 +563,8 @@
 	*/
 
 /mob/living/carbon/superior_animal/Life()
+	. = ..()
+
 	ticks_processed++
 	handle_regular_hud_updates()
 	if(!reagent_immune)
@@ -608,6 +610,9 @@
 				SSmove_manager.stop_looping(src)
 				last_followed = null // this exists so we only stop the following once, no need to constantly end our walk
 
+/*	life_cycles_before_sleep and life_cycles_before_scan are already handled on /mob/living/Life()
+	So, why is any of this even here?
+
 	if(life_cycles_before_sleep)
 		life_cycles_before_sleep--
 		return TRUE
@@ -623,6 +628,7 @@
 		return TRUE
 	life_cycles_before_scan = initial(life_cycles_before_scan)
 	return FALSE
+*/
 
 /**
  *  Handles telegraphing attacks, and attack delays. It does not handle the attacks themselves.

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -314,15 +314,15 @@
 				if(!atmos_suitable)
 					adjustBruteLoss(unsuitable_atoms_damage)
 
-		if(!AI_inactive)
+		if(incapacitated())
+			return TRUE
+
+		else
 			//Speaking
 			if(!client && speak_chance)
 				if(rand(0,200) < speak_chance)
 					visible_emote(emote_see)
 					speak_audio()
-
-			if(incapacitated())
-				return TRUE
 
 			//Movement
 			turns_since_move++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
<details>
<summary>
	simple_mobs were going comatose due to AI_inactive impeding their move/speech handles. Now they will wander and talk unless incapacitated.
	Superior_animals had a redundant \life_cycles_before_sleep and life_cycles_before_scan\ check while Life() already handles it in mob/living
</summary>
<hr>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
	
<hr>
</details>

## Changelog
:cl:

tweak: tweaked a few things

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
