### PR TITLE
tweaks toolimplant multy

### DIFF
--- a/code/datums/craft/recipes/tools.dm
+++ b/code/datums/craft/recipes/tools.dm
@@ -115,7 +115,7 @@
 // In case you want it in your hands and not implanted
 /datum/craft_recipe/tool/makeshift_omnitool
 	name = "\improper Improvised omnitool"
-	result = /obj/item/tool/multitool_improvised
+	result = /obj/item/organ_module/active/simple/makeshift
 	steps = list(
 		list(/obj/item/organ_module/active/simple/makeshift, 1),
 		list(QUALITY_PULSING, 20),

--- a/code/datums/craft/recipes/tools.dm
+++ b/code/datums/craft/recipes/tools.dm
@@ -112,16 +112,17 @@
 		list(QUALITY_ADHESIVE, 15, 70)
 	)
 
-// In case you want it in your hands and not implanted
+/* In case you want it in your hands and not implanted
+Disabled as this is meant to be implant not free floating
 /datum/craft_recipe/tool/makeshift_omnitool
 	name = "\improper Improvised omnitool"
-	result = /obj/item/organ_module/active/simple/makeshift
+	result = /obj/item/tool/multitool_improvised
 	steps = list(
 		list(/obj/item/organ_module/active/simple/makeshift, 1),
 		list(QUALITY_PULSING, 20),
 		list(QUALITY_PRYING, 20, "time" = 140)
 	)
-
+*/
 //Outsider tape more or less
 /datum/craft_recipe/tool/webtape
 	name = "web tape"

--- a/code/game/objects/items/devices/organ_module/active/multitool/makeshift_multy.dm
+++ b/code/game/objects/items/devices/organ_module/active/multitool/makeshift_multy.dm
@@ -2,6 +2,6 @@
 	name = "embedded Makeshift multitool"
 	desc = "A jury-rigged implant, holding cobbled-together tools. For those who are more interested in tool carrying than scared of tetanus."
 	verb_name = "Deploy makeshift omnitool"
-	icon_state = "multitool"
+	icon_state = "multitool_improvised"
 	allowed_organs = list(BP_R_ARM, BP_L_ARM)
 	holding_type = /obj/item/tool/multitool_improvised

--- a/maps/__Liberty/map/_Liberty_Colony.dmm
+++ b/maps/__Liberty/map/_Liberty_Colony.dmm
@@ -12920,7 +12920,7 @@
 	dir = 1;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon  Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous  Oxide","waste_sensor"="Gas  Mix  Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon    Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous    Oxide","waste_sensor"="Gas    Mix    Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/engineering/atmos/surface)
@@ -35093,7 +35093,7 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon  Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous  Oxide","waste_sensor"="Gas  Mix  Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon    Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous    Oxide","waste_sensor"="Gas    Mix    Tank")
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/liberty/engineering/atmos/surface)
@@ -52251,8 +52251,8 @@
 /area/liberty/maintenance/undergroundfloor1central)
 "lwA" = (
 /obj/structure/table/steel_reinforced,
-/obj/item/tool/multitool_improvised,
-/obj/item/tool/multitool_improvised,
+/obj/item/organ_module/active/simple/makeshift,
+/obj/item/organ_module/active/simple/makeshift,
 /obj/item/reagent_containers/food/drinks/cans/monster_sol,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/liberty/engineering/atmos/storage)


### PR DESCRIPTION
You can no longer remove the implant aspect of makeshift multy tool
Replaces makeshift multy tool tools with the proper implant
Gives the makeshift multy tool icon to the makeshift multy implant