### PR TITLE
less mobs

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -42,6 +42,11 @@
 	var/old_lock_odds = 0 //Changes the access lock to something that must be hacked or CC access
 			      //If their is already a lock on this, it overrides it.
 
+	var/mob_sounds = "Subtle whispers of rustling emanate from within."
+	var/has_mobs_to_spawn = FALSE
+	var/chance_old_mobs = 20
+	var/mobs_to_spawn = /obj/random/cluster/roaches
+
 /obj/structure/closet/can_prevent_fall()
 	return TRUE
 
@@ -58,6 +63,9 @@
 
 	if (prob(old_chance))
 		make_old()
+		if(prob(chance_old_mobs) && !has_mobs_to_spawn)
+			has_mobs_to_spawn = TRUE
+			mobs_to_spawn = /obj/random/cluster/roaches
 
 	if (prob(old_lock_odds + old_chance))
 		make_lock_old()
@@ -93,6 +101,8 @@
 /obj/structure/closet/examine(mob/user)
 	if(..(user, 1) && !opened && !istype(src, /obj/structure/closet/body_bag))
 		var/content_size = 0
+		if(has_mobs_to_spawn)
+			to_chat(user, "[mob_sounds]")
 		for(var/obj/item/I in src.contents)
 			if(!I.anchored)
 				content_size += CEILING(I.w_class * 0.5, 1)
@@ -201,6 +211,10 @@
 			s.start()
 			if(user.stunned)
 				return FALSE
+
+	if(has_mobs_to_spawn && mobs_to_spawn)
+		has_mobs_to_spawn = FALSE
+		new mobs_to_spawn(src.loc)
 
 	playsound(loc, open_sound, 100, 1, -3)
 	opened = TRUE

--- a/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
+++ b/code/game/objects/structures/crates_lockers/closets/maint_loot.dm
@@ -5,6 +5,7 @@
 	desc = "Old and rusty closet, probably older than you."
 	icon_state = "oldstyle"
 	old_chance = 50
+	chance_old_mobs = 50
 
 /obj/structure/closet/random_miscellaneous/populate_contents()
 	new /obj/random/contraband/low_chance(src)
@@ -22,7 +23,6 @@
 	new /obj/random/pack/cloth/low_chance(src)
 	new /obj/random/pack/gun_loot/low_chance(src)
 	new /obj/random/pouch/hardcase_scrap/low_chance(src)
-	new /obj/random/cluster/roaches/lower_chance(src)
 	new /obj/random/gun_parts/low(src)
 	if(prob(20))
 		new /obj/random/gun_parts/frames(src)
@@ -33,6 +33,7 @@
 	icon_state = "eng"
 	icon_door = "eng_tool"
 	old_chance = 10
+	chance_old_mobs = 25
 
 /obj/structure/closet/random_tech/populate_contents()
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -46,7 +47,6 @@
 	new /obj/random/pouch/hardcase_scrap(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
-	new /obj/random/cluster/roaches/lower_chance(src)
 	if(prob(30))
 		new /obj/random/gun_parts/frames(src)
 
@@ -56,6 +56,7 @@
 	icon_state = "eng"
 	icon_door = "eng_tool"
 	old_chance = 10
+	chance_old_mobs = 25
 
 /obj/structure/closet/random_tech/populate_contents()
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -76,7 +77,6 @@
 	new /obj/random/pouch/hardcase_scrap/low_chance(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
 	new /obj/random/pack/tech_loot/low_chance(src)
-	new /obj/random/cluster/roaches/lower_chance(src)
 	if(prob(20))
 		new /obj/random/gun_parts/frames(src)
 
@@ -85,6 +85,7 @@
 	desc = "Why is this here?"
 	icon_state = "syndicate"
 	old_chance = 10
+	chance_old_mobs = 75
 
 /obj/structure/closet/random_milsupply/populate_contents()
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -108,7 +109,6 @@
 	new /obj/random/medical/low_chance(src)
 	new /obj/random/medical/low_chance(src)
 	new /obj/random/pouch/hardcase_scrap/low_chance(src)
-	new /obj/random/cluster/roaches/lower_chance(src)
 	new /obj/random/gun_parts/low(src)
 	new /obj/random/gun_parts/low(src)
 	new /obj/random/gun_parts/frames(src)
@@ -121,6 +121,7 @@
 	desc = "Abandoned medical supply."
 	icon_state = "freezer"
 	old_chance = 10
+	chance_old_mobs = 15
 
 /obj/structure/closet/random_medsupply/populate_contents()
 	new /obj/random/lowkeyrandom/low_chance(src)
@@ -137,13 +138,13 @@
 	new /obj/random/medical/low_chance(src)
 	new /obj/random/medical/low_chance(src)
 	new /obj/random/pouch/hardcase_scrap/low_chance(src)
-	new /obj/random/cluster/roaches/lower_chance(src)
 
 /obj/structure/closet/secure_closet/rare_loot
 	name = "\improper sealed military supply closet"
 	desc = "The access panel looks old. There is probably no ID's around that can open it."
 	req_access = list(access_cent_specops) //You are suppose to hack it
 	icon_state = "syndicate"
+	chance_old_mobs = 75
 
 /obj/structure/closet/secure_closet/rare_loot/populate_contents()
 	new /obj/random/pack/rare(src)
@@ -156,7 +157,6 @@
 	new /obj/random/pack/gun_loot(src)
 	new /obj/random/pack/gun_loot(src)
 	new /obj/random/pouch/hardcase_scrap/low_chance(src)
-	new /obj/random/cluster/roaches/lower_chance(src)
 	new /obj/random/gun_parts(src)
 	new /obj/random/gun_parts(src)
 	new /obj/random/gun_parts/low(src)
@@ -173,6 +173,7 @@
 	desc = "Old and rusty closet, probably older than you."
 	icon_state = "oldstyle"
 	old_chance = 70
+	chance_old_mobs = 95
 
 /obj/structure/closet/random_hostilemobs/populate_contents()
 	new /obj/random/pack/rare(src) //To reward players for fighting this bullshit
@@ -187,11 +188,14 @@
 	new /obj/random/rations(src)
 	new /obj/random/rations(src)
 	new /obj/random/pouch/hardcase_scrap/low_chance(src)
-	new /obj/random/cluster/roaches(src)
 	if(prob(30))
 		new /obj/random/gun_parts/frames(src)
 
 // Used for scrap beacon
+/obj/structure/closet/random_hostilemobs/beacon
+	mobs_to_spawn = /obj/random/cluster/roaches/beacon
+	has_mobs_to_spawn = TRUE //These always have roaches
+
 /obj/structure/closet/random_hostilemobs/beacon/populate_contents()
 	new /obj/random/pack/rare(src) //To reward players for fighting this bullshit
 	new /obj/random/pack/rare(src)
@@ -204,6 +208,5 @@
 	new /obj/random/rations(src)
 	new /obj/random/rations(src)
 	new /obj/random/rations(src)
-	new /obj/random/cluster/roaches/beacon(src)
 	if(prob(15))
 		new /obj/random/gun_parts/frames(src)


### PR DESCRIPTION
Mobs inside of lockers now have a tell, this tell can be inaccurate as its spawners can spawn nothing so you can be tricked!
This in theory shouldnt do much to reduce lag but according to SoJ it helps a lot.

Code wise mobs inside lockers wait to spawn untill opened, destorying the locker directly will not cause the mobs to spawn
this is *intented* as your expending ammo to bypass fighting mobs inside